### PR TITLE
[#18] PresignedURL 발급 기능을 구현한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// s3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 	// test
 	testImplementation 'io.rest-assured:rest-assured:5.5.0'
 	testImplementation 'com.h2database:h2'

--- a/src/docs/asciidoc/storage.adoc
+++ b/src/docs/asciidoc/storage.adoc
@@ -1,0 +1,17 @@
+:toc: left
+:source-highlighter: highlightjs
+:sectlinks:
+:toclevels: 2
+:sectlinks:
+:sectnums:
+
+== Storage
+
+=== PresignedUrl 발급 (GET /api/storage/presigned-url)
+==== 요청
+include::{snippets}/storage-controller-web-mvc-test/스토리지_경로_요청/http-request.adoc[]
+include::{snippets}/storage-controller-web-mvc-test/스토리지_경로_요청/request-headers.adoc[]
+include::{snippets}/storage-controller-web-mvc-test/스토리지_경로_요청/query-parameters.adoc[]
+==== 응답
+include::{snippets}/storage-controller-web-mvc-test/스토리지_경로_요청/http-response.adoc[]
+include::{snippets}/storage-controller-web-mvc-test/스토리지_경로_요청/response-fields.adoc[]

--- a/src/main/java/com/flab/eattofit/member/config/auth/MemberAuthConfig.java
+++ b/src/main/java/com/flab/eattofit/member/config/auth/MemberAuthConfig.java
@@ -12,6 +12,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
+import static com.flab.eattofit.global.config.interceptor.support.HttpMethod.GET;
 import static com.flab.eattofit.global.config.interceptor.support.HttpMethod.OPTIONS;
 import static com.flab.eattofit.global.config.interceptor.support.HttpMethod.POST;
 
@@ -36,7 +37,8 @@ public class MemberAuthConfig implements WebMvcConfigurer {
 
     private HandlerInterceptor loginValidCheckerInterceptor() {
         return new PathMatcherInterceptor(memberLoginValidCheckerInterceptor)
-                .excludePathPatterns("/api/auth/login/**", POST);
+                .excludePathPatterns("/api/auth/login/**", POST)
+                .addPathPatterns("/api/storage/**", GET);
     }
 
     @Override

--- a/src/main/java/com/flab/eattofit/storage/application/StorageManager.java
+++ b/src/main/java/com/flab/eattofit/storage/application/StorageManager.java
@@ -1,0 +1,8 @@
+package com.flab.eattofit.storage.application;
+
+import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
+
+public interface StorageManager {
+
+    PresignedUrlResponse getPresignedUrl(Long memberId, String resource, String fileName);
+}

--- a/src/main/java/com/flab/eattofit/storage/application/StorageManager.java
+++ b/src/main/java/com/flab/eattofit/storage/application/StorageManager.java
@@ -1,8 +1,7 @@
 package com.flab.eattofit.storage.application;
 
-import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
-
 public interface StorageManager {
 
-    PresignedUrlResponse getPresignedUrl(String resource, String fileName);
+    String getPresignedUrl(String resource, String fileName);
+    String getFileUrl(String resource, String fileName);
 }

--- a/src/main/java/com/flab/eattofit/storage/application/StorageManager.java
+++ b/src/main/java/com/flab/eattofit/storage/application/StorageManager.java
@@ -4,5 +4,5 @@ import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
 
 public interface StorageManager {
 
-    PresignedUrlResponse getPresignedUrl(Long memberId, String resource, String fileName);
+    PresignedUrlResponse getPresignedUrl(String resource, String fileName);
 }

--- a/src/main/java/com/flab/eattofit/storage/application/StorageService.java
+++ b/src/main/java/com/flab/eattofit/storage/application/StorageService.java
@@ -19,7 +19,7 @@ public class StorageService {
     public PresignedUrlResponse getPresignedUrl(final Long memberId, final String resource, final String name) {
         ResourceType resourceType = ResourceType.findByName(resource);
         String fileName = generateFileName(memberId, name);
-        return storageManager.getPresignedUrl(memberId, resourceType.getName(), fileName);
+        return storageManager.getPresignedUrl(resourceType.getName(), fileName);
     }
     
     private String generateFileName(final Long memberId, final String name) {

--- a/src/main/java/com/flab/eattofit/storage/application/StorageService.java
+++ b/src/main/java/com/flab/eattofit/storage/application/StorageService.java
@@ -1,0 +1,42 @@
+package com.flab.eattofit.storage.application;
+
+import com.flab.eattofit.storage.domain.ExtensionType;
+import com.flab.eattofit.storage.domain.ResourceType;
+import com.flab.eattofit.storage.exception.exceptions.BadFileNameException;
+import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class StorageService {
+
+    private static final String EXTENSION_MARK = ".";
+    private static final String MEMBER_MARK = "-";
+
+    private final StorageManager storageManager;
+
+    public PresignedUrlResponse getPresignedUrl(final Long memberId, final String resource, final String name) {
+        ResourceType resourceType = ResourceType.findByName(resource);
+        String fileName = generateFileName(memberId, name);
+        return storageManager.getPresignedUrl(memberId, resourceType.getName(), fileName);
+    }
+    
+    private String generateFileName(final Long memberId, final String name) {
+        int extensionIndex = getExtensionIndexFromFileName(name);
+
+        String originName = name.substring(0, extensionIndex);
+        String extension = name.substring(extensionIndex + 1);
+        ExtensionType extensionType = ExtensionType.findByName(extension);
+
+        return originName + MEMBER_MARK + memberId + EXTENSION_MARK + extensionType.getName();
+    }
+
+    private int getExtensionIndexFromFileName(final String name) {
+        int extensionIndex = name.lastIndexOf(EXTENSION_MARK);
+        if (extensionIndex == -1 || extensionIndex == name.length() - 1) {
+            throw new BadFileNameException();
+        }
+        return extensionIndex;
+    }
+}

--- a/src/main/java/com/flab/eattofit/storage/application/StorageService.java
+++ b/src/main/java/com/flab/eattofit/storage/application/StorageService.java
@@ -19,7 +19,11 @@ public class StorageService {
     public PresignedUrlResponse getPresignedUrl(final Long memberId, final String resource, final String name) {
         ResourceType resourceType = ResourceType.findByName(resource);
         String fileName = generateFileName(memberId, name);
-        return storageManager.getPresignedUrl(resourceType.getName(), fileName);
+
+        String presignedUrl = storageManager.getPresignedUrl(resourceType.getName(), fileName);
+        String fileUrl = storageManager.getFileUrl(resourceType.getName(), fileName);
+
+        return new PresignedUrlResponse(presignedUrl, fileUrl);
     }
     
     private String generateFileName(final Long memberId, final String name) {

--- a/src/main/java/com/flab/eattofit/storage/config/S3Config.java
+++ b/src/main/java/com/flab/eattofit/storage/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.flab.eattofit.storage.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/flab/eattofit/storage/domain/ExtensionType.java
+++ b/src/main/java/com/flab/eattofit/storage/domain/ExtensionType.java
@@ -1,0 +1,31 @@
+package com.flab.eattofit.storage.domain;
+
+import com.flab.eattofit.storage.exception.exceptions.NotFoundExtensionTypeException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum ExtensionType {
+
+    JPG("jpg"),
+    JPEG("jpeg"),
+    PNG("png");
+
+    private final String name;
+
+    ExtensionType(final String name) {
+        this.name = name;
+    }
+
+    public static ExtensionType findByName(final String name) {
+        return Arrays.stream(values())
+                .filter(extensionType -> extensionType.isSame(name))
+                .findAny()
+                .orElseThrow(NotFoundExtensionTypeException::new);
+    }
+
+    private boolean isSame(final String name) {
+        return name.equals(this.name);
+    }
+}

--- a/src/main/java/com/flab/eattofit/storage/domain/ResourceType.java
+++ b/src/main/java/com/flab/eattofit/storage/domain/ResourceType.java
@@ -1,0 +1,30 @@
+package com.flab.eattofit.storage.domain;
+
+import com.flab.eattofit.storage.exception.exceptions.NotFoundResourceTypeException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum ResourceType {
+
+    PROFILE("profile"),
+    FOOD("food");
+
+    private final String name;
+
+    ResourceType(final String name) {
+        this.name = name;
+    }
+
+    public static ResourceType findByName(final String name) {
+        return Arrays.stream(values())
+                .filter(resourceType -> resourceType.isSame(name))
+                .findAny()
+                .orElseThrow(NotFoundResourceTypeException::new);
+    }
+
+    private boolean isSame(final String name) {
+        return name.equals(this.name);
+    }
+}

--- a/src/main/java/com/flab/eattofit/storage/exception/exceptions/BadFileNameException.java
+++ b/src/main/java/com/flab/eattofit/storage/exception/exceptions/BadFileNameException.java
@@ -1,0 +1,11 @@
+package com.flab.eattofit.storage.exception.exceptions;
+
+import com.flab.eattofit.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class BadFileNameException extends GlobalException {
+
+    public BadFileNameException() {
+        super(HttpStatus.BAD_REQUEST, "BAD_FILE_NAME", "확장자명이 없습니다.");
+    }
+}

--- a/src/main/java/com/flab/eattofit/storage/exception/exceptions/NotFoundExtensionTypeException.java
+++ b/src/main/java/com/flab/eattofit/storage/exception/exceptions/NotFoundExtensionTypeException.java
@@ -1,0 +1,11 @@
+package com.flab.eattofit.storage.exception.exceptions;
+
+import com.flab.eattofit.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundExtensionTypeException extends GlobalException {
+
+    public NotFoundExtensionTypeException() {
+        super(HttpStatus.NOT_FOUND, "NOT_FOUND_EXTENSION_TYPE", "등록되지 않은 확장자 타입입니다.");
+    }
+}

--- a/src/main/java/com/flab/eattofit/storage/exception/exceptions/NotFoundResourceTypeException.java
+++ b/src/main/java/com/flab/eattofit/storage/exception/exceptions/NotFoundResourceTypeException.java
@@ -1,0 +1,11 @@
+package com.flab.eattofit.storage.exception.exceptions;
+
+import com.flab.eattofit.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundResourceTypeException extends GlobalException {
+
+    public NotFoundResourceTypeException() {
+        super(HttpStatus.NOT_FOUND, "NOT_FOUND_RESOURCE_TYPE", "등록되지 않은 리소스명 입니다.");
+    }
+}

--- a/src/main/java/com/flab/eattofit/storage/infrastructure/S3StorageManager.java
+++ b/src/main/java/com/flab/eattofit/storage/infrastructure/S3StorageManager.java
@@ -4,7 +4,6 @@ import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.flab.eattofit.storage.application.StorageManager;
-import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -31,12 +30,14 @@ public class S3StorageManager implements StorageManager {
     private final AmazonS3 amazonS3;
 
     @Override
-    public PresignedUrlResponse getPresignedUrl(final String resource, final String fileName) {
-        String key = String.format(KEY_FORMAT, resource, fileName);
+    public String getPresignedUrl(final String resource, final String fileName) {
+        String key = generateKey(resource, fileName);
         URL presignedUrl = generatePresignedUrl(key);
-        String fileUrl = String.format(S3_URL_FORMAT, bucket, amazonS3.getRegionName(), key);
+        return presignedUrl.toString();
+    }
 
-        return new PresignedUrlResponse(presignedUrl.toString(), fileUrl);
+    private String generateKey(final String resource, final String fileName) {
+        return String.format(KEY_FORMAT, resource, fileName);
     }
 
     private URL generatePresignedUrl(final String key) {
@@ -52,5 +53,11 @@ public class S3StorageManager implements StorageManager {
         Instant expirationInstant = now.plusMinutes(expiration)
                 .toInstant(ZoneOffset.UTC);
         return Date.from(expirationInstant);
+    }
+
+    @Override
+    public String getFileUrl(final String resource, final String fileName) {
+        String key = generateKey(resource, fileName);
+        return String.format(S3_URL_FORMAT, bucket, amazonS3.getRegionName(), key);
     }
 }

--- a/src/main/java/com/flab/eattofit/storage/infrastructure/S3StorageManager.java
+++ b/src/main/java/com/flab/eattofit/storage/infrastructure/S3StorageManager.java
@@ -31,7 +31,7 @@ public class S3StorageManager implements StorageManager {
     private final AmazonS3 amazonS3;
 
     @Override
-    public PresignedUrlResponse getPresignedUrl(final Long memberId, final String resource, final String fileName) {
+    public PresignedUrlResponse getPresignedUrl(final String resource, final String fileName) {
         String key = String.format(KEY_FORMAT, resource, fileName);
         URL presignedUrl = generatePresignedUrl(key);
         String fileUrl = String.format(S3_URL_FORMAT, bucket, amazonS3.getRegionName(), key);

--- a/src/main/java/com/flab/eattofit/storage/infrastructure/S3StorageManager.java
+++ b/src/main/java/com/flab/eattofit/storage/infrastructure/S3StorageManager.java
@@ -1,0 +1,56 @@
+package com.flab.eattofit.storage.infrastructure;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.flab.eattofit.storage.application.StorageManager;
+import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URL;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+public class S3StorageManager implements StorageManager {
+
+    private static final String KEY_FORMAT = "%s/%s";
+    private static final String S3_URL_FORMAT = "https://%s.s3.%s.amazonaws.com/%s";
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.presigned-url-expiration-period}")
+    private int expiration;
+
+    private final AmazonS3 amazonS3;
+
+    @Override
+    public PresignedUrlResponse getPresignedUrl(final Long memberId, final String resource, final String fileName) {
+        String key = String.format(KEY_FORMAT, resource, fileName);
+        URL presignedUrl = generatePresignedUrl(key);
+        String fileUrl = String.format(S3_URL_FORMAT, bucket, amazonS3.getRegionName(), key);
+
+        return new PresignedUrlResponse(presignedUrl.toString(), fileUrl);
+    }
+
+    private URL generatePresignedUrl(final String key) {
+        GeneratePresignedUrlRequest presignedUrlRequest = new GeneratePresignedUrlRequest(bucket, key)
+                .withMethod(HttpMethod.PUT)
+                .withExpiration(getExpiration());
+
+        return amazonS3.generatePresignedUrl(presignedUrlRequest);
+    }
+
+    private Date getExpiration() {
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+        Instant expirationInstant = now.plusMinutes(expiration)
+                .toInstant(ZoneOffset.UTC);
+        return Date.from(expirationInstant);
+    }
+}

--- a/src/main/java/com/flab/eattofit/storage/infrastructure/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/flab/eattofit/storage/infrastructure/dto/PresignedUrlResponse.java
@@ -1,0 +1,7 @@
+package com.flab.eattofit.storage.infrastructure.dto;
+
+public record PresignedUrlResponse(
+        String presignedUrl,
+        String fileUrl
+) {
+}

--- a/src/main/java/com/flab/eattofit/storage/ui/StorageController.java
+++ b/src/main/java/com/flab/eattofit/storage/ui/StorageController.java
@@ -1,0 +1,29 @@
+package com.flab.eattofit.storage.ui;
+
+import com.flab.eattofit.member.ui.auth.support.annotations.AuthMember;
+import com.flab.eattofit.storage.application.StorageService;
+import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/storage")
+@RestController
+public class StorageController {
+
+    private final StorageService storageService;
+
+    @GetMapping("/presigned-url")
+    public ResponseEntity<PresignedUrlResponse> getPresignedUrl(
+            @AuthMember Long memberId,
+            @RequestParam("resource") final String resource,
+            @RequestParam("name") final String name
+    ) {
+        return ResponseEntity.ok()
+                .body(storageService.getPresignedUrl(memberId, resource, name));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,13 @@ jwt:
   refresh-secret: ENC(lZiQpKftGJ5dxgsN5LXps2VezF9fGyNE/BHITmZgBmUTQ7j2i/EpbRP1zJp38PyxTSnSMlC597DdFFwzg2KIOMt7stauOrdrCxLMKt4GYPwPd4K4WSUQDrCdHt0T2LAPMZQUa4+cgiA5WfgAtr3WCaAit+L3TbpM9TcCVMcPzdVqNT5AYXgmgbboyhNouZ0D)
   access-token-expiration-period: 1
   refresh-token-expiration-period: 7
+
+cloud:
+  aws:
+    s3:
+      bucketName: eattofit
+      presigned-url-expiration-period: 15
+    region: ap-northeast-2
+    credentials:
+      access-key: ENC(8B/TChJBPDj8JwUxw7QVcIJ7h27dPGz4L1rIKtWgezo=)
+      secret-key: ENC(ZaNYTjLi94Xb4csfVdrr22B3nrWkdZHwDo8ga20ScZU54YSbEFLBjTqJ0IE6jh+LCIbQgZEapjk=)

--- a/src/test/java/com/flab/eattofit/helper/MockBeanInjection.java
+++ b/src/test/java/com/flab/eattofit/helper/MockBeanInjection.java
@@ -1,5 +1,6 @@
 package com.flab.eattofit.helper;
 
+import com.amazonaws.services.s3.AmazonS3;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.flab.eattofit.member.application.auth.AuthService;
 import com.flab.eattofit.member.application.auth.OAuthManager;
@@ -13,6 +14,8 @@ import com.flab.eattofit.member.ui.auth.support.MemberAuthenticationExtractor;
 import com.flab.eattofit.member.ui.auth.support.OAuthProperties;
 import com.flab.eattofit.member.ui.auth.support.resolver.AuthMemberArgumentResolver;
 import com.flab.eattofit.member.ui.auth.support.resolver.OAuthArgumentResolver;
+import com.flab.eattofit.storage.application.StorageManager;
+import com.flab.eattofit.storage.application.StorageService;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
@@ -58,4 +61,14 @@ public class MockBeanInjection {
 
     @MockBean
     protected RefreshTokenRepository refreshTokenRepository;
+
+    // storage
+    @MockBean
+    protected StorageService storageService;
+
+    @MockBean
+    protected StorageManager storageManager;
+
+    @MockBean
+    protected AmazonS3 amazonS3;
 }

--- a/src/test/java/com/flab/eattofit/storage/application/StorageServiceTest.java
+++ b/src/test/java/com/flab/eattofit/storage/application/StorageServiceTest.java
@@ -1,0 +1,79 @@
+package com.flab.eattofit.storage.application;
+
+import com.flab.eattofit.storage.exception.exceptions.BadFileNameException;
+import com.flab.eattofit.storage.exception.exceptions.NotFoundExtensionTypeException;
+import com.flab.eattofit.storage.exception.exceptions.NotFoundResourceTypeException;
+import com.flab.eattofit.storage.infrastructure.FakeStorageManager;
+import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class StorageServiceTest {
+
+    private StorageService storageService;
+
+    @BeforeEach
+    void init() {
+        storageService = new StorageService(new FakeStorageManager());
+    }
+
+    @Test
+    void presigned_url과_파일_저장_경로를_받는다() {
+        // given
+        Long memberId = 1L;
+        String resource = "profile";
+        String name = "test.jpg";
+
+        // when
+        PresignedUrlResponse response = storageService.getPresignedUrl(memberId, resource, name);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.presignedUrl()).isNotEmpty();
+            softly.assertThat(response.fileUrl()).isNotEmpty();
+        });
+    }
+
+    @Test
+    void 가능한_자원_타입이_아닐_경우_예외가_발생한다() {
+        // given
+        Long memberId = 1L;
+        String resource = "abc";
+        String name = "test.jpg";
+
+        // when & then
+        assertThatThrownBy(() -> storageService.getPresignedUrl(memberId, resource, name))
+                .isInstanceOf(NotFoundResourceTypeException.class);
+    }
+
+    @Test
+    void 가능한_확장자_타입이_아닐_경우_예외가_발생한다() {
+        // given
+        Long memberId = 1L;
+        String resource = "profile";
+        String name = ".hello";
+
+        // when & then
+        assertThatThrownBy(() -> storageService.getPresignedUrl(memberId, resource, name))
+                .isInstanceOf(NotFoundExtensionTypeException.class);
+    }
+
+    @Test
+    void 확장자_구분이_없을_경우_예외가_발생한다() {
+        // given
+        Long memberId = 1L;
+        String resource = "profile";
+        String name = "hello";
+
+        // when & then
+        assertThatThrownBy(() -> storageService.getPresignedUrl(memberId, resource, name))
+                .isInstanceOf(BadFileNameException.class);
+    }
+}

--- a/src/test/java/com/flab/eattofit/storage/domain/ExtensionTypeTest.java
+++ b/src/test/java/com/flab/eattofit/storage/domain/ExtensionTypeTest.java
@@ -1,0 +1,40 @@
+package com.flab.eattofit.storage.domain;
+
+import com.flab.eattofit.storage.exception.exceptions.NotFoundExtensionTypeException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ExtensionTypeTest {
+
+    @Test
+    void 확장자_타입을_조회한다() {
+        // given
+        String type = "jpg";
+        ExtensionType expectedType = ExtensionType.JPG;
+
+        // when
+        ExtensionType extension = ExtensionType.findByName(type);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(extension).isEqualTo(expectedType);
+            softly.assertThat(extension.getName()).isEqualTo(type);
+        });
+    }
+
+    @Test
+    void 없는_확장자_조회_시_예외가_발생한다() {
+        // given
+        String type = "abc";
+
+        // when & then
+        assertThatThrownBy(() -> ExtensionType.findByName(type))
+                .isInstanceOf(NotFoundExtensionTypeException.class);
+    }
+}

--- a/src/test/java/com/flab/eattofit/storage/domain/ResourceTypeTest.java
+++ b/src/test/java/com/flab/eattofit/storage/domain/ResourceTypeTest.java
@@ -1,0 +1,40 @@
+package com.flab.eattofit.storage.domain;
+
+import com.flab.eattofit.storage.exception.exceptions.NotFoundResourceTypeException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ResourceTypeTest {
+
+    @Test
+    void 스토리지_자원_타입을_조회한다() {
+        // given
+        String type = "food";
+        ResourceType expectedType = ResourceType.FOOD;
+
+        // when
+        ResourceType resourceType = ResourceType.findByName(type);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(resourceType).isEqualTo(expectedType);
+            softly.assertThat(resourceType.getName()).isEqualTo(type);
+        });
+    }
+
+    @Test
+    void 없는_스토리지_자원_타입을_조회하면_예외가_발생한다() {
+        // given
+        String type = "abc";
+
+        // when & then
+        assertThatThrownBy(() -> ResourceType.findByName(type))
+                .isInstanceOf(NotFoundResourceTypeException.class);
+    }
+}

--- a/src/test/java/com/flab/eattofit/storage/infrastructure/FakeStorageManager.java
+++ b/src/test/java/com/flab/eattofit/storage/infrastructure/FakeStorageManager.java
@@ -1,0 +1,16 @@
+package com.flab.eattofit.storage.infrastructure;
+
+import com.flab.eattofit.storage.application.StorageManager;
+import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
+
+public class FakeStorageManager implements StorageManager {
+
+    private static final String FAKE_STORAGE = "http://fake.storage.com";
+
+    @Override
+    public PresignedUrlResponse getPresignedUrl(final String resource, final String fileName) {
+        String fileUrl = FAKE_STORAGE + "/" + resource + "/" + fileName;
+        String presignedUrl = fileUrl + "?type=fake";
+        return new PresignedUrlResponse(presignedUrl, fileUrl);
+    }
+}

--- a/src/test/java/com/flab/eattofit/storage/infrastructure/FakeStorageManager.java
+++ b/src/test/java/com/flab/eattofit/storage/infrastructure/FakeStorageManager.java
@@ -1,16 +1,19 @@
 package com.flab.eattofit.storage.infrastructure;
 
 import com.flab.eattofit.storage.application.StorageManager;
-import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
 
 public class FakeStorageManager implements StorageManager {
 
     private static final String FAKE_STORAGE = "http://fake.storage.com";
 
     @Override
-    public PresignedUrlResponse getPresignedUrl(final String resource, final String fileName) {
+    public String getPresignedUrl(final String resource, final String fileName) {
         String fileUrl = FAKE_STORAGE + "/" + resource + "/" + fileName;
-        String presignedUrl = fileUrl + "?type=fake";
-        return new PresignedUrlResponse(presignedUrl, fileUrl);
+        return fileUrl + "?type=fake";
+    }
+
+    @Override
+    public String getFileUrl(final String resource, final String fileName) {
+        return FAKE_STORAGE + "/" + resource + "/" + fileName;
     }
 }

--- a/src/test/java/com/flab/eattofit/storage/ui/StorageControllerWebMvcTest.java
+++ b/src/test/java/com/flab/eattofit/storage/ui/StorageControllerWebMvcTest.java
@@ -1,0 +1,70 @@
+package com.flab.eattofit.storage.ui;
+
+import com.flab.eattofit.helper.MockBeanInjection;
+import com.flab.eattofit.storage.infrastructure.dto.PresignedUrlResponse;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.flab.eattofit.helper.RestDocsHelper.customDocument;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@AutoConfigureRestDocs
+@WebMvcTest(StorageController.class)
+class StorageControllerWebMvcTest extends MockBeanInjection {
+
+    private static final String BEARER_TOKEN = "Bearer token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void presigned_url과_파일_저장_경로를_요청한다() throws Exception {
+        // given
+        String resource = "food";
+        String name = "hamburger.jpg";
+        String presignedUrl = "http://storage.com/food/hamburger-1.jpg?env=test...";
+        String fileUrl = "http://storage.com/food/hamburger-1.jpg";
+
+        when(storageService.getPresignedUrl(any(), any(), any()))
+                .thenReturn(new PresignedUrlResponse(presignedUrl, fileUrl));
+
+        // when & then
+        mockMvc.perform(get("/api/storage/presigned-url")
+                        .header(AUTHORIZATION, BEARER_TOKEN)
+                        .param("resource", resource)
+                        .param("name", name))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(customDocument("스토리지_경로_요청",
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("유저 토큰 정보")
+                        ),
+                        queryParameters(
+                            parameterWithName("resource").description("리소스 종류 (food, profile)"),
+                                parameterWithName("name").description("파일 이름")
+                        ),
+                        responseFields(
+                                fieldWithPath("presignedUrl").description("Presigned URL"),
+                                fieldWithPath("fileUrl").description("File URL")
+                        )
+                ));
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -55,3 +55,13 @@ oauth:
       user-info-key-word-request:
         email-key-word: email
         name-key-word: name
+
+cloud:
+  aws:
+    s3:
+      bucketName: test
+      presigned-url-expiration-period: 15
+    region: test-region
+    credentials:
+      access-key: access-key
+      secret-key: secret-key


### PR DESCRIPTION
## 📢 Related Issue
<!-- 연결된 이슈를 등록해주세요. -->
* #18 
## 💁🏻 Summary
<!-- Pull Request의 전체적인 내용을 작성해주세요. -->
* S3을 연결하여 presigned url을 발급하는 기능을 구현하였습니다.
* query parameter로 발급할 자원 (profile, food)과, 저장할 파일의 이름을 받도록 하였습니다.
  * 발급 가능한 자원이 아니라면 예외가 발생합니다.
  * 저장할 파일의 이름이 중복될 경우에 대비하여, 파일의 이름 마지막에 `-{회원 id}.확장자`로 저장되도록 하였습니다.
  * 저장 가능한 확장자는 jpg, jpeg, png로 제한하였습니다.
## 🧐 More
<!-- Pull Request와 관련된 고민, 리뷰어와 논의할 내용이 있다면 작성해주세요. -->
미리 논의하고 싶은 부분을 말씀드리겠습니다.
* presigned url 발급에 대한 API를 통합한 만큼, 본 기능이 구현된 코드 패키지도 어느 한 곳에 모아둬야겠다고 생각했습니다. 그래서 src > food, src > member 이런 식 보다는 src > storage를 만든 뒤 이 곳에 보관해두는 방식을 이용했는데 적절한 방향인지 궁금합니다.
* S3StorageManager에 대한 테스트는 우선 하지 않았습니다. S3과 직접적으로 연결되었기 때문인데, 테스트 할 수 있는 방식이 크게 [S3Mock](https://wedul.site/704#google_vignette)과 [LocalStack](https://techblog.woowahan.com/2638/)이 있음을 알게 되었습니다. 그런데 대부분 참고 자료를 보면 실제적으로 S3에 파일이 업로드 되었는지를 테스트하기 위해 썼었던 경우인데, 저의 경우에는 단순히 S3에 대한 presigned url을 발급해주는 용도로만 사용하기 때문에 S3에 대한 통합 테스트를 해야 할까라는 의문이 있었습니다. 이 부분에 대해서도 논의드려보고 싶습니다.

close #18 