### PR TITLE
[#19] 음식 검색 기능을 구현한다 (ChatGPT)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,13 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
 }
 
 ext {
 	jwtVersion = '0.12.6'
 	snippetsDir = file('build/generated-snippets')
+	set('springAiVersion', "1.0.0-M2")
 }
 
 dependencies {
@@ -35,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
 
 	// jasypt
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
@@ -67,6 +70,12 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+	}
 }
 
 test {

--- a/src/docs/asciidoc/food.adoc
+++ b/src/docs/asciidoc/food.adoc
@@ -1,0 +1,19 @@
+:toc: left
+:source-highlighter: highlightjs
+:sectlinks:
+:toclevels: 2
+:sectlinks:
+:sectnums:
+
+== Food
+
+=== 음식 검색 (GET /api/foods/search)
+
+==== 요청
+include::{snippets}/food-controller-web-mvc-test/음식_검색/http-request.adoc[]
+include::{snippets}/food-controller-web-mvc-test/음식_검색/request-headers.adoc[]
+include::{snippets}/food-controller-web-mvc-test/음식_검색/query-parameters.adoc[]
+
+==== 응답
+include::{snippets}/food-controller-web-mvc-test/음식_검색/http-response.adoc[]
+include::{snippets}/food-controller-web-mvc-test/음식_검색/response-fields.adoc[]

--- a/src/main/java/com/flab/eattofit/food/application/FoodService.java
+++ b/src/main/java/com/flab/eattofit/food/application/FoodService.java
@@ -1,0 +1,17 @@
+package com.flab.eattofit.food.application;
+
+import com.flab.eattofit.food.domain.FoodSearchManager;
+import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class FoodService {
+
+    private final FoodSearchManager foodSearchManager;
+
+    public PredictFoodSearchResponse foodSearch(String url) {
+        return foodSearchManager.search(url);
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/application/FoodService.java
+++ b/src/main/java/com/flab/eattofit/food/application/FoodService.java
@@ -3,15 +3,18 @@ package com.flab.eattofit.food.application;
 import com.flab.eattofit.food.domain.FoodSearchManager;
 import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class FoodService {
 
     private final FoodSearchManager foodSearchManager;
 
-    public PredictFoodSearchResponse foodSearch(final String url) {
+    public PredictFoodSearchResponse foodSearch(final Long memberId, final String url) {
+        log.info("{} 회원이 {}로 음식 검색 요청", memberId, url);
         return foodSearchManager.search(url);
     }
 }

--- a/src/main/java/com/flab/eattofit/food/application/FoodService.java
+++ b/src/main/java/com/flab/eattofit/food/application/FoodService.java
@@ -11,7 +11,7 @@ public class FoodService {
 
     private final FoodSearchManager foodSearchManager;
 
-    public PredictFoodSearchResponse foodSearch(String url) {
+    public PredictFoodSearchResponse foodSearch(final String url) {
         return foodSearchManager.search(url);
     }
 }

--- a/src/main/java/com/flab/eattofit/food/domain/FoodSearchManager.java
+++ b/src/main/java/com/flab/eattofit/food/domain/FoodSearchManager.java
@@ -1,0 +1,8 @@
+package com.flab.eattofit.food.domain;
+
+import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
+
+public interface FoodSearchManager {
+
+    PredictFoodSearchResponse search(String url);
+}

--- a/src/main/java/com/flab/eattofit/food/exception/BadImageUrlException.java
+++ b/src/main/java/com/flab/eattofit/food/exception/BadImageUrlException.java
@@ -1,0 +1,11 @@
+package com.flab.eattofit.food.exception;
+
+import com.flab.eattofit.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class BadImageUrlException extends GlobalException {
+
+    public BadImageUrlException() {
+        super(HttpStatus.BAD_REQUEST, "BAD_IMAGE_URL", "이미지 주소가 잘못되었습니다.");
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/exception/FoodSearchJsonParseException.java
+++ b/src/main/java/com/flab/eattofit/food/exception/FoodSearchJsonParseException.java
@@ -1,0 +1,11 @@
+package com.flab.eattofit.food.exception;
+
+import com.flab.eattofit.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class FoodSearchJsonParseException extends GlobalException {
+
+    public FoodSearchJsonParseException() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, "FOOD_SEARCH_JSON_PARSE", "음식 정보를 파싱하는 데 예외가 발생했습니다.");
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/infrastructure/OpenAiFoodSearchManager.java
+++ b/src/main/java/com/flab/eattofit/food/infrastructure/OpenAiFoodSearchManager.java
@@ -1,0 +1,89 @@
+package com.flab.eattofit.food.infrastructure;
+
+import com.flab.eattofit.food.domain.FoodSearchManager;
+import com.flab.eattofit.food.exception.BadImageUrlException;
+import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MimeTypeUtils;
+
+import java.net.MalformedURLException;
+
+@RequiredArgsConstructor
+@Component
+public class OpenAiFoodSearchManager implements FoodSearchManager {
+
+    private final ChatClient chatClient;
+
+    @Override
+    public PredictFoodSearchResponse search(final String url) {
+        BeanOutputConverter<PredictFoodSearchResponse> parser = new BeanOutputConverter<>(PredictFoodSearchResponse.class);
+
+        String response = chatClient.prompt()
+                .user(userSpec -> {
+                    try {
+                        userSpec.text(
+                                """
+                                <role>
+                                너는 20년 이상 음식 경력을 가진 요리사 겸 영양사다. 음식 사진을 주면, 제공된 format에 맞춰 응답해야 한다.
+                                </role>
+                                <instruction>
+                                1. 예측 가능한 음식은 최소 3개 이상 나와야 한다.
+                                2. unit은 'g'로 고정한다.
+                                3. servingSize는 gram 기준으로 계산한다.
+                                4. servingSize, kcal, carbohydrate, protein, fat, sodium은 모두 소수점 둘째 자리까지 표현되어야 한다.
+                                5. 소수점 둘째 자리들로 표현을 할 때, 이것들이 모두 0으로 된 경우가 아닌 경우도 있을 수 있다. (0으로 된 경우가 있을 수도 있다.)
+                                6. name은 한글 기준으로 나와야 한다.
+                                </instruction>
+                                <example>
+                                예시 응답을 알려주겠다. 예시 응답과 같은 음식이 나오더라도 이 예시 값을 똑같이 활용하지는 마라.
+                                {
+                                    "predictFoods": [
+                                        {
+                                            "name": "비빔밥",
+                                            "servingSize": 488.02,
+                                            "unit": "g",
+                                            "kcal": 635.31,
+                                            "carbohydrate": 97.13,
+                                            "protein": 24.21,
+                                            "fat": 16.23,
+                                            "sodium": 1248.24
+                                        },
+                                        {
+                                            "name": "산채비빔밥",
+                                            "servingSize": 433.24,
+                                            "unit": "g",
+                                            "kcal": 596.83,
+                                            "carbohydrate": 93.21,
+                                            "protein": 17.82,
+                                            "fat": 16.23,
+                                            "sodium": 1135.35
+                                        },
+                                        {
+                                            "name": "돌솥비빔밥",
+                                            "servingSize": 430.24,
+                                            "unit": "g",
+                                            "kcal": 656.51,
+                                            "carbohydrate": 93.23,
+                                            "protein": 17.39,
+                                            "fat": 18.66,
+                                            "sodium": 1135.35
+                                        }
+                                    ]
+                                }
+                                </example>
+                                format은 아래와 같다.
+                                """ + parser.getFormat())
+                                .media(MimeTypeUtils.IMAGE_JPEG, new UrlResource(url));
+                    } catch (MalformedURLException e) {
+                        throw new BadImageUrlException();
+                    }
+                })
+                .call()
+                .content();
+        return parser.convert(response);
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/infrastructure/OpenAiFoodSearchManager.java
+++ b/src/main/java/com/flab/eattofit/food/infrastructure/OpenAiFoodSearchManager.java
@@ -37,6 +37,7 @@ public class OpenAiFoodSearchManager implements FoodSearchManager {
                                 4. servingSize, kcal, carbohydrate, protein, fat, sodium은 모두 소수점 둘째 자리까지 표현되어야 한다.
                                 5. 소수점 둘째 자리들로 표현을 할 때, 이것들이 모두 0으로 된 경우가 아닌 경우도 있을 수 있다. (0으로 된 경우가 있을 수도 있다.)
                                 6. name은 한글 기준으로 나와야 한다.
+                                7. 만약 음식이 아니라면, predictFoods를 빈 배열로 반환하라.
                                 </instruction>
                                 <example>
                                 예시 응답을 알려주겠다. 예시 응답과 같은 음식이 나오더라도 이 예시 값을 똑같이 활용하지는 마라.

--- a/src/main/java/com/flab/eattofit/food/infrastructure/OpenAiFoodSearchManager.java
+++ b/src/main/java/com/flab/eattofit/food/infrastructure/OpenAiFoodSearchManager.java
@@ -38,7 +38,7 @@ public class OpenAiFoodSearchManager implements FoodSearchManager {
     private void generateSearchFoodPrompt(
             final String url,
             final ChatClient.PromptUserSpec userSpec,
-            final BeanOutputConverter<PredictFoodSearchResponse> parser
+            final BeanOutputConverter<PredictFoodSearchResponse> converter
     ) throws MalformedURLException {
         userSpec.text(
                 """
@@ -92,7 +92,7 @@ public class OpenAiFoodSearchManager implements FoodSearchManager {
                 }
                 </example>
                 format은 아래와 같다.
-                """ + parser.getFormat())
+                """ + converter.getFormat())
                 .media(MimeTypeUtils.IMAGE_JPEG, new UrlResource(url));
     }
 }

--- a/src/main/java/com/flab/eattofit/food/infrastructure/OpenAiFoodSearchManager.java
+++ b/src/main/java/com/flab/eattofit/food/infrastructure/OpenAiFoodSearchManager.java
@@ -25,60 +25,7 @@ public class OpenAiFoodSearchManager implements FoodSearchManager {
         String response = chatClient.prompt()
                 .user(userSpec -> {
                     try {
-                        userSpec.text(
-                                """
-                                <role>
-                                너는 20년 이상 음식 경력을 가진 요리사 겸 영양사다. 음식 사진을 주면, 제공된 format에 맞춰 응답해야 한다.
-                                </role>
-                                <instruction>
-                                1. 예측 가능한 음식은 최소 3개 이상 나와야 한다.
-                                2. unit은 'g'로 고정한다.
-                                3. servingSize는 gram 기준으로 계산한다.
-                                4. servingSize, kcal, carbohydrate, protein, fat, sodium은 모두 소수점 둘째 자리까지 표현되어야 한다.
-                                5. 소수점 둘째 자리들로 표현을 할 때, 이것들이 모두 0으로 된 경우가 아닌 경우도 있을 수 있다. (0으로 된 경우가 있을 수도 있다.)
-                                6. name은 한글 기준으로 나와야 한다.
-                                7. 만약 음식이 아니라면, predictFoods를 빈 배열로 반환하라.
-                                </instruction>
-                                <example>
-                                예시 응답을 알려주겠다. 예시 응답과 같은 음식이 나오더라도 이 예시 값을 똑같이 활용하지는 마라.
-                                {
-                                    "predictFoods": [
-                                        {
-                                            "name": "비빔밥",
-                                            "servingSize": 488.02,
-                                            "unit": "g",
-                                            "kcal": 635.31,
-                                            "carbohydrate": 97.13,
-                                            "protein": 24.21,
-                                            "fat": 16.23,
-                                            "sodium": 1248.24
-                                        },
-                                        {
-                                            "name": "산채비빔밥",
-                                            "servingSize": 433.24,
-                                            "unit": "g",
-                                            "kcal": 596.83,
-                                            "carbohydrate": 93.21,
-                                            "protein": 17.82,
-                                            "fat": 16.23,
-                                            "sodium": 1135.35
-                                        },
-                                        {
-                                            "name": "돌솥비빔밥",
-                                            "servingSize": 430.24,
-                                            "unit": "g",
-                                            "kcal": 656.51,
-                                            "carbohydrate": 93.23,
-                                            "protein": 17.39,
-                                            "fat": 18.66,
-                                            "sodium": 1135.35
-                                        }
-                                    ]
-                                }
-                                </example>
-                                format은 아래와 같다.
-                                """ + parser.getFormat())
-                                .media(MimeTypeUtils.IMAGE_JPEG, new UrlResource(url));
+                        generateSearchFoodPrompt(url, userSpec, parser);
                     } catch (MalformedURLException e) {
                         throw new BadImageUrlException();
                     }
@@ -86,5 +33,66 @@ public class OpenAiFoodSearchManager implements FoodSearchManager {
                 .call()
                 .content();
         return parser.convert(response);
+    }
+
+    private void generateSearchFoodPrompt(
+            final String url,
+            final ChatClient.PromptUserSpec userSpec,
+            final BeanOutputConverter<PredictFoodSearchResponse> parser
+    ) throws MalformedURLException {
+        userSpec.text(
+                """
+                <role>
+                너는 20년 이상 음식 경력을 가진 요리사 겸 영양사다. 음식 사진을 주면, 제공된 format에 맞춰 응답해야 한다.
+                </role>
+                <instruction>
+                1. 예측 가능한 음식은 최소 3개 이상 나와야 한다.
+                2. unit은 'g'로 고정한다.
+                3. servingSize는 gram 기준으로 계산한다.
+                4. servingSize, kcal, carbohydrate, protein, fat, sodium은 모두 소수점 둘째 자리까지 표현되어야 한다.
+                5. 소수점 둘째 자리들로 표현을 할 때, 이것들이 모두 0으로 된 경우가 아닌 경우도 있을 수 있다. (0으로 된 경우가 있을 수도 있다.)
+                6. name은 한글 기준으로 나와야 한다.
+                7. 만약 음식이 아니라면, predictFoods를 빈 배열로 반환하라.
+                </instruction>
+                <example>
+                예시 응답을 알려주겠다. 예시 응답과 같은 음식이 나오더라도 이 예시 값을 똑같이 활용하지는 마라.
+                {
+                    "predictFoods": [
+                        {
+                            "name": "비빔밥",
+                            "servingSize": 488.02,
+                            "unit": "g",
+                            "kcal": 635.31,
+                            "carbohydrate": 97.13,
+                            "protein": 24.21,
+                            "fat": 16.23,
+                            "sodium": 1248.24
+                        },
+                        {
+                            "name": "산채비빔밥",
+                            "servingSize": 433.24,
+                            "unit": "g",
+                            "kcal": 596.83,
+                            "carbohydrate": 93.21,
+                            "protein": 17.82,
+                            "fat": 16.23,
+                            "sodium": 1135.35
+                        },
+                        {
+                            "name": "돌솥비빔밥",
+                            "servingSize": 430.24,
+                            "unit": "g",
+                            "kcal": 656.51,
+                            "carbohydrate": 93.23,
+                            "protein": 17.39,
+                            "fat": 18.66,
+                            "sodium": 1135.35
+                        }
+                    ]
+                }
+                </example>
+                format은 아래와 같다.
+                """ + parser.getFormat())
+                .media(MimeTypeUtils.IMAGE_JPEG, new UrlResource(url));
     }
 }

--- a/src/main/java/com/flab/eattofit/food/infrastructure/dto/FoodSearchResponse.java
+++ b/src/main/java/com/flab/eattofit/food/infrastructure/dto/FoodSearchResponse.java
@@ -1,0 +1,15 @@
+package com.flab.eattofit.food.infrastructure.dto;
+
+import java.math.BigDecimal;
+
+public record FoodSearchResponse(
+        String name,
+        BigDecimal servingSize,
+        String unit,
+        BigDecimal kcal,
+        BigDecimal carbohydrate,
+        BigDecimal protein,
+        BigDecimal fat,
+        BigDecimal sodium
+) {
+}

--- a/src/main/java/com/flab/eattofit/food/infrastructure/dto/PredictFoodSearchResponse.java
+++ b/src/main/java/com/flab/eattofit/food/infrastructure/dto/PredictFoodSearchResponse.java
@@ -1,0 +1,8 @@
+package com.flab.eattofit.food.infrastructure.dto;
+
+import java.util.List;
+
+public record PredictFoodSearchResponse(
+        List<FoodSearchResponse> predictFoods
+) {
+}

--- a/src/main/java/com/flab/eattofit/food/ui/FoodController.java
+++ b/src/main/java/com/flab/eattofit/food/ui/FoodController.java
@@ -2,6 +2,7 @@ package com.flab.eattofit.food.ui;
 
 import com.flab.eattofit.food.application.FoodService;
 import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
+import com.flab.eattofit.member.ui.auth.support.annotations.AuthMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,8 +20,11 @@ public class FoodController {
     private final FoodService foodService;
 
     @GetMapping("/search")
-    public ResponseEntity<PredictFoodSearchResponse> search(final @RequestParam(value = IMAGE_URL) String imageUrl) {
-        PredictFoodSearchResponse response = foodService.foodSearch(imageUrl);
+    public ResponseEntity<PredictFoodSearchResponse> search(
+            final @AuthMember Long memberId,
+            final @RequestParam(value = IMAGE_URL) String imageUrl
+    ) {
+        PredictFoodSearchResponse response = foodService.foodSearch(memberId, imageUrl);
         return ResponseEntity.ok()
                 .body(response);
     }

--- a/src/main/java/com/flab/eattofit/food/ui/FoodController.java
+++ b/src/main/java/com/flab/eattofit/food/ui/FoodController.java
@@ -1,0 +1,27 @@
+package com.flab.eattofit.food.ui;
+
+import com.flab.eattofit.food.application.FoodService;
+import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/foods")
+@RestController
+public class FoodController {
+
+    private static final String IMAGE_URL = "image_url";
+
+    private final FoodService foodService;
+
+    @GetMapping("/search")
+    public ResponseEntity<PredictFoodSearchResponse> search(final @RequestParam(value = IMAGE_URL) String imageUrl) {
+        PredictFoodSearchResponse response = foodService.foodSearch(imageUrl);
+        return ResponseEntity.ok()
+                .body(response);
+    }
+}

--- a/src/main/java/com/flab/eattofit/global/config/AiConfig.java
+++ b/src/main/java/com/flab/eattofit/global/config/AiConfig.java
@@ -1,0 +1,22 @@
+package com.flab.eattofit.global.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AiConfig {
+
+    @Value("${spring.ai.openai.api-key}")
+    private String apiKey;
+
+    @Bean
+    public ChatClient chatClient() {
+        ChatModel chatModel = new OpenAiChatModel(new OpenAiApi(apiKey));
+        return ChatClient.create(chatModel);
+    }
+}

--- a/src/main/java/com/flab/eattofit/member/config/auth/MemberAuthConfig.java
+++ b/src/main/java/com/flab/eattofit/member/config/auth/MemberAuthConfig.java
@@ -38,7 +38,8 @@ public class MemberAuthConfig implements WebMvcConfigurer {
     private HandlerInterceptor loginValidCheckerInterceptor() {
         return new PathMatcherInterceptor(memberLoginValidCheckerInterceptor)
                 .excludePathPatterns("/api/auth/login/**", POST)
-                .addPathPatterns("/api/storage/**", GET);
+                .addPathPatterns("/api/storage/**", GET)
+                .addPathPatterns("/api/foods/**", GET);
     }
 
     @Override

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,6 +20,9 @@ spring:
       host: localhost
       port: 6379
       password:
+  ai:
+    openai:
+      api-key: ENC(z2qI+jL6Ws27r00O+vkSWFRGmz84Wckkc+OePq1eVM/nLcdTj9WclhbaMbKy3wU2y9FtGRwdrGttK0DfNSS2N6ejQRcBZbTZRBoWg3jmPHOdyihXDKlO1/+oMW7BzgJS1dpWV1BBFhcNPkSUs2eYfvz1sGzltgapZrI4nBraFec4aH8csX7Eoc95JM18ZCCDYDeatYDUTayPN/3Ed5rwXpan0tTjZfUFjn+3VQ8NML8=)
 oauth:
   properties:
     kakao:

--- a/src/test/java/com/flab/eattofit/food/application/FoodServiceTest.java
+++ b/src/test/java/com/flab/eattofit/food/application/FoodServiceTest.java
@@ -1,0 +1,102 @@
+package com.flab.eattofit.food.application;
+
+import com.flab.eattofit.food.domain.FoodSearchManager;
+import com.flab.eattofit.food.exception.BadImageUrlException;
+import com.flab.eattofit.food.exception.FoodSearchJsonParseException;
+import com.flab.eattofit.food.infrastructure.dto.FoodSearchResponse;
+import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_아님_빈_목록;
+import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_응답_비빔밥;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.when;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class FoodServiceTest {
+
+    @Mock
+    private FoodSearchManager foodSearchManager;
+
+    private FoodService foodService;
+
+    @BeforeEach
+    void init() {
+        foodService = new FoodService(foodSearchManager);
+    }
+
+    @Nested
+    class 음식_검색 {
+
+        @Test
+        void 음식을_검색한다() {
+            // given
+            Long memberId = 1L;
+            String url = "www.food.com/bibimbap.jpg";
+            when(foodSearchManager.search(url)).thenReturn(new PredictFoodSearchResponse(음식_응답_비빔밥()));
+
+            // when
+            PredictFoodSearchResponse response = foodService.foodSearch(memberId, url);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.predictFoods()).isNotEmpty();
+                softly.assertThat(response.predictFoods()).extracting(FoodSearchResponse::name)
+                        .containsExactly(
+                                "비빔밥",
+                                "산채비빔밥",
+                                "돌솥비빔밥"
+                        );
+            });
+        }
+
+        @Test
+        void 사진이_음식이_아니면_빈_목록을_반환한다() {
+            // given
+            Long memberId = 1L;
+            String url = "www.image.com/car.jpg";
+            when(foodSearchManager.search(url)).thenReturn(new PredictFoodSearchResponse(음식_아님_빈_목록()));
+
+            // when
+            PredictFoodSearchResponse response = foodService.foodSearch(memberId, url);
+
+            // then
+            assertThat(response.predictFoods()).isEmpty();
+        }
+
+        @Test
+        void 사진_경로가_잘못되면_예외가_발생한다() {
+            // given
+            Long memberId = 1L;
+            String url = "abcd";
+            when(foodSearchManager.search(url)).thenThrow(BadImageUrlException.class);
+
+            // when & then
+            assertThatThrownBy(() -> foodService.foodSearch(memberId, url))
+                    .isInstanceOf(BadImageUrlException.class);
+        }
+
+        @Test
+        void 반환_형태가_다르면_예외가_발생한다() {
+            // given
+            Long memberId = 1L;
+            String url = "www.food.com/burger.jpg";
+            when(foodSearchManager.search(url)).thenThrow(FoodSearchJsonParseException.class);
+
+            // when & then
+            assertThatThrownBy(() -> foodService.foodSearch(memberId, url))
+                    .isInstanceOf(FoodSearchJsonParseException.class);
+        }
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/fixture/FoodSearchResponseFixture.java
+++ b/src/test/java/com/flab/eattofit/food/fixture/FoodSearchResponseFixture.java
@@ -45,4 +45,8 @@ public class FoodSearchResponseFixture {
                 )
         );
     }
+
+    public static List<FoodSearchResponse> 음식_아님_빈_목록() {
+        return List.of();
+    }
 }

--- a/src/test/java/com/flab/eattofit/food/fixture/FoodSearchResponseFixture.java
+++ b/src/test/java/com/flab/eattofit/food/fixture/FoodSearchResponseFixture.java
@@ -1,0 +1,48 @@
+package com.flab.eattofit.food.fixture;
+
+import com.flab.eattofit.food.infrastructure.dto.FoodSearchResponse;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class FoodSearchResponseFixture {
+
+    public static List<FoodSearchResponse> 음식_응답_비빔밥() {
+        return List.of(
+                new FoodSearchResponse(
+                        "비빔밥",
+                        BigDecimal.valueOf(488.02),
+                        "g",
+                        BigDecimal.valueOf(635.31),
+                        BigDecimal.valueOf(97.13),
+                        BigDecimal.valueOf(24.21),
+                        BigDecimal.valueOf(16.23),
+                        BigDecimal.valueOf(1248.24)
+                ),
+                new FoodSearchResponse(
+                        "산채비빔밥",
+                        BigDecimal.valueOf(433.24),
+                        "g",
+                        BigDecimal.valueOf(596.83),
+                        BigDecimal.valueOf(93.21),
+                        BigDecimal.valueOf(17.82),
+                        BigDecimal.valueOf(16.23),
+                        BigDecimal.valueOf(1135.35)
+                ),
+                new FoodSearchResponse(
+                        "돌솥비빔밥",
+                        BigDecimal.valueOf(430.24),
+                        "g",
+                        BigDecimal.valueOf(656.51),
+                        BigDecimal.valueOf(93.23),
+                        BigDecimal.valueOf(17.39),
+                        BigDecimal.valueOf(18.66),
+                        BigDecimal.valueOf(1135.35)
+                )
+        );
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/ui/FoodControllerAcceptanceTest.java
+++ b/src/test/java/com/flab/eattofit/food/ui/FoodControllerAcceptanceTest.java
@@ -1,7 +1,6 @@
 package com.flab.eattofit.food.ui;
 
 import com.flab.eattofit.food.application.FoodService;
-import com.flab.eattofit.food.fixture.FoodSearchResponseFixture;
 import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
 import com.flab.eattofit.member.domain.member.Member;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/flab/eattofit/food/ui/FoodControllerAcceptanceTest.java
+++ b/src/test/java/com/flab/eattofit/food/ui/FoodControllerAcceptanceTest.java
@@ -1,0 +1,47 @@
+package com.flab.eattofit.food.ui;
+
+import com.flab.eattofit.food.application.FoodService;
+import com.flab.eattofit.food.fixture.FoodSearchResponseFixture;
+import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
+import com.flab.eattofit.member.domain.member.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_응답_비빔밥;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class FoodControllerAcceptanceTest extends FoodControllerAcceptanceTestFixture {
+
+    private static final String 음식_검색_URL = "/api/foods/search?image_url=www.food.com/bibimbap.jpg";
+
+    @MockBean
+    private FoodService foodService;
+
+    private String 토큰;
+    private Member 회원;
+
+    @BeforeEach
+    void init() {
+        회원 = 회원_생성();
+        토큰 = 토큰_발급(회원);
+    }
+
+    @Test
+    void 음식_검색() {
+        // given
+        var 음식_검색_목록 = new PredictFoodSearchResponse(음식_응답_비빔밥());
+        when(foodService.foodSearch(any(), any())).thenReturn(음식_검색_목록);
+
+        // when
+        var 음식_검색_요청_결과 = 음식_검색_요청(음식_검색_URL, 토큰);
+
+        // then
+        음식_검색_요청_결과_검증(음식_검색_요청_결과);
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/ui/FoodControllerAcceptanceTestFixture.java
+++ b/src/test/java/com/flab/eattofit/food/ui/FoodControllerAcceptanceTestFixture.java
@@ -1,0 +1,53 @@
+package com.flab.eattofit.food.ui;
+
+import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
+import com.flab.eattofit.helper.IntegrationHelper;
+import com.flab.eattofit.member.domain.auth.TokenManager;
+import com.flab.eattofit.member.domain.member.Member;
+import com.flab.eattofit.member.domain.member.MemberRepository;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpStatus.OK;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class FoodControllerAcceptanceTestFixture extends IntegrationHelper {
+
+    @Autowired
+    private TokenManager tokenManager;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    protected Member 회원_생성() {
+        return memberRepository.save(Member.of("member@email.gom", "nickname"));
+    }
+
+    protected String 토큰_발급(final Member member) {
+        return tokenManager.generateAccessToken(member.getId());
+    }
+
+    protected ExtractableResponse<Response> 음식_검색_요청(final String url, final String token) {
+        return RestAssured.given().log().all()
+                .header(AUTHORIZATION, "Bearer " + token)
+                .when()
+                .get(url)
+                .then()
+                .extract();
+    }
+
+    protected void 음식_검색_요청_결과_검증(final ExtractableResponse<Response> response) {
+        PredictFoodSearchResponse result = response.as(PredictFoodSearchResponse.class);
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
+            softly.assertThat(result.predictFoods()).isNotEmpty();
+        });
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/ui/FoodControllerAcceptanceTestFixture.java
+++ b/src/test/java/com/flab/eattofit/food/ui/FoodControllerAcceptanceTestFixture.java
@@ -27,7 +27,7 @@ public class FoodControllerAcceptanceTestFixture extends IntegrationHelper {
     private MemberRepository memberRepository;
 
     protected Member 회원_생성() {
-        return memberRepository.save(Member.of("member@email.gom", "nickname"));
+        return memberRepository.save(Member.of("member@email.com", "nickname"));
     }
 
     protected String 토큰_발급(final Member member) {

--- a/src/test/java/com/flab/eattofit/food/ui/FoodControllerWebMvcTest.java
+++ b/src/test/java/com/flab/eattofit/food/ui/FoodControllerWebMvcTest.java
@@ -1,0 +1,71 @@
+package com.flab.eattofit.food.ui;
+
+import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
+import com.flab.eattofit.helper.MockBeanInjection;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.flab.eattofit.helper.RestDocsHelper.customDocument;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_응답_비빔밥;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@AutoConfigureRestDocs
+@WebMvcTest(FoodController.class)
+class FoodControllerWebMvcTest extends MockBeanInjection {
+
+    private static final String BEARER_TOKEN = "Bearer token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void 음식을_검색한다() throws Exception {
+        // given
+        String url = "www.food.com/bibimbap.jpg";
+        when(foodService.foodSearch(any(), any())).thenReturn(new PredictFoodSearchResponse(음식_응답_비빔밥()));
+
+        // when & then
+        mockMvc.perform(get("/api/foods/search")
+                        .param("image_url", url)
+                        .header(AUTHORIZATION, BEARER_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(customDocument("음식_검색",
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("유저 토큰 정보")
+                        ),
+                        queryParameters(
+                                parameterWithName("image_url").description("음식 사진이 위치한 이미지 주소")
+                        ),
+                        responseFields(
+                                fieldWithPath("predictFoods").description("예측된 음식 목록"),
+                                fieldWithPath("predictFoods[].name").description("음식 이름"),
+                                fieldWithPath("predictFoods[].servingSize").description("음식 무게 (unit 기준)"),
+                                fieldWithPath("predictFoods[].unit").description("음식 무게 단위 (g, kg)"),
+                                fieldWithPath("predictFoods[].kcal").description("음식 칼로리"),
+                                fieldWithPath("predictFoods[].carbohydrate").description("음식 탄수화물"),
+                                fieldWithPath("predictFoods[].protein").description("음식 단백질"),
+                                fieldWithPath("predictFoods[].fat").description("음식 지방"),
+                                fieldWithPath("predictFoods[].sodium").description("음식 나트륨")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/flab/eattofit/helper/MockBeanInjection.java
+++ b/src/test/java/com/flab/eattofit/helper/MockBeanInjection.java
@@ -6,6 +6,7 @@ import com.flab.eattofit.exercise.application.fitness.FitnessService;
 import com.flab.eattofit.exercise.application.sports.SportsService;
 import com.flab.eattofit.exercise.domain.fitness.FitnessRepository;
 import com.flab.eattofit.exercise.domain.sports.SportsRepository;
+import com.flab.eattofit.food.application.FoodService;
 import com.flab.eattofit.member.application.auth.AuthService;
 import com.flab.eattofit.member.application.auth.OAuthManager;
 import com.flab.eattofit.member.domain.auth.RefreshTokenRepository;
@@ -89,4 +90,8 @@ public class MockBeanInjection {
 
     @MockBean
     protected SportsRepository sportsRepository;
+
+    // food
+    @MockBean
+    protected FoodService foodService;
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,7 +18,9 @@ spring:
       host: localhost
       port: 6379
       password:
-
+  ai:
+    openai:
+      api-key: gptgptgptgptgptgptgptgptgpt
 logging:
   level:
     org:


### PR DESCRIPTION
## 📢 Related Issue
<!-- 연결된 이슈를 등록해주세요. -->
* #19 
## 💁🏻 Summary
<!-- Pull Request의 전체적인 내용을 작성해주세요. -->
* 음식 검색 기능을 구현하였습니다.
* 원래는 두잉랩의 AI API를 이용해야 했으나, API 만료가 되어 음식 검색 기능도 Spring AI를 이용하여 구현하기로 하였습니다.
  * 덕분에 Spring AI에서 언젠가 다뤄야 했던 부분인 `JSON 파싱`과 `이미지 분석` 요청에 대해 알게 되었습니다. ([기록한 글](https://devwriter.tistory.com/57))
  * Spring AI의 ChatGPT 기본 모델은 `gpt 4-o`로 되어 있습니다.
* 이미지 파일은 직접 올리지 않고 URL을 통해 올리도록 하였습니다. 전달 타입은 우선은 JPEG로 고정하였습니다.
* 음식 응답인 PredictFoodSearchResponse와 FoodSearchResponse는 음식의 정보에 핵심적으로 관여되어, 이것을 만드는 FoodSearchManager 인터페이스의 위치도 도메인 패키지에 두었습니다.
* 현재 프롬프트가 String으로 관리되는데, 향후 플랜 생성 기능에서도 프롬프트를 작성하는 만큼 추후 프롬프트 파일을 resources에 보관 및 AOP로 간편히 조회하는 기능을 구현할 계획입니다.
* 인증된 회원만 사용할 수 있도록 하였고, 회원의 id를 이용해 로깅하도록 하였습니다.
* 서비스 테스트에서 FoodSearchManager를 `@Mock`을 써서 검증했습니다. 외부에서 전달해주기만 하는 것인만큼, 이전에 fake repository를 만들었을 때와는 다르게 직접 mocking을 하고 발생할 수 있는 결과를 mockito로 제어하는 것이 필수라고 생각하였습니다.

아래는 postman을 통한 예시입니다.
![스크린샷 2024-09-29 오후 5 21 27](https://github.com/user-attachments/assets/95da5c90-4d72-440e-8ab9-e8a66a53081e)

## 🧐 More
<!-- Pull Request와 관련된 고민, 리뷰어와 논의할 내용이 있다면 작성해주세요. -->
인수 테스트에서 mocking을 하는 것에서 고민이 있었습니다.
현재 구현한 FoodControllerAcceptanceTest에서는, 조회를 했을 때 데이터를 mocking으로 지정해둬야 테스트가 가능합니다.
그런데 그동안 이해했을 때에는 인수 테스트는 개발자가 아닌 사람들도 이해할 수 있도록 작성해야 하는 것으로 알고 있었는데, mockito 코드가 들어감에 따라 `개발자가 아닌 사람들이 이해할 수 없는 코드`가 들어간 것은 아닌지 조금 고민이 되었습니다.
```java
@Test
void 음식_검색() {
    // given
    var 음식_검색_목록 = new PredictFoodSearchResponse(음식_응답_비빔밥());
    when(foodService.foodSearch(any(), any())).thenReturn(음식_검색_목록); // 이 부분이 고민입니다.

    // when
    var 음식_검색_요청_결과 = 음식_검색_요청(음식_검색_URL, 토큰);

    // then
    음식_검색_요청_결과_검증(음식_검색_요청_결과);
}
```
대체할 수 있는 방식으로는 [WireMock](https://techblog.woowahan.com/17674/)이 있음을 알게 되었는데, Mockito에 비해 WireMock이 [실제 HTTP 요청을 모방할 수 있다](https://stackoverflow.com/questions/50726017/why-we-should-use-wiremock-instead-of-mockito)는 점에서 인수 테스트에 쓰면 좋을 것 같다는 생각이 들었는데 WireMock을 쓰면 어떨지도 생각이 들었었습니다.

close #19 