### PR TITLE
[#20] 음식 등록 기능을 구현한다

### DIFF
--- a/src/docs/asciidoc/food.adoc
+++ b/src/docs/asciidoc/food.adoc
@@ -7,6 +7,18 @@
 
 == Food
 
+=== 음식 생성 (POST /api/foods)
+
+==== 요청
+include::{snippets}/food-controller-web-mvc-test/음식 생성/http-request.adoc[]
+include::{snippets}/food-controller-web-mvc-test/음식 생성/request-headers.adoc[]
+include::{snippets}/food-controller-web-mvc-test/음식 생성/request-fields.adoc[]
+
+==== 응답
+include::{snippets}/food-controller-web-mvc-test/음식 생성/http-response.adoc[]
+include::{snippets}/food-controller-web-mvc-test/음식 생성/response-headers.adoc[]
+include::{snippets}/food-controller-web-mvc-test/음식 생성/response-fields.adoc[]
+
 === 음식 검색 (GET /api/foods/search)
 
 ==== 요청

--- a/src/main/java/com/flab/eattofit/food/application/FoodService.java
+++ b/src/main/java/com/flab/eattofit/food/application/FoodService.java
@@ -37,7 +37,7 @@ public class FoodService {
                 .fat(request.fat())
                 .sodium(request.sodium())
                 .build();
-        Food food = Food.createWith(request.name(), weight, nutrient, memberId);
+        Food food = Food.createWith(request.name(), weight, nutrient, request.url(), memberId);
 
         return foodRepository.save(food);
     }

--- a/src/main/java/com/flab/eattofit/food/application/FoodService.java
+++ b/src/main/java/com/flab/eattofit/food/application/FoodService.java
@@ -1,6 +1,11 @@
 package com.flab.eattofit.food.application;
 
+import com.flab.eattofit.food.application.dto.FoodCreateRequest;
+import com.flab.eattofit.food.domain.Food;
+import com.flab.eattofit.food.domain.FoodRepository;
 import com.flab.eattofit.food.domain.FoodSearchManager;
+import com.flab.eattofit.food.domain.vo.FoodNutrient;
+import com.flab.eattofit.food.domain.vo.FoodWeight;
 import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -12,10 +17,29 @@ public class FoodService {
 
     private static final String FOOD_SEARCH_MANAGER = "doinglabFoodSearchManager";
 
+    private final FoodRepository foodRepository;
     private final FoodSearchManager foodSearchManager;
 
-    public FoodService(@Qualifier(value = FOOD_SEARCH_MANAGER) final FoodSearchManager foodSearchManager) {
+    public FoodService(
+            final FoodRepository foodRepository,
+            @Qualifier(value = FOOD_SEARCH_MANAGER) final FoodSearchManager foodSearchManager
+    ) {
+        this.foodRepository = foodRepository;
         this.foodSearchManager = foodSearchManager;
+    }
+
+    public Food createFood(final FoodCreateRequest request, final Long memberId) {
+        FoodWeight weight = FoodWeight.createWith(request.servingSize(), request.unit());
+        FoodNutrient nutrient = FoodNutrient.builder()
+                .kcal(request.kcal())
+                .carbohydrate(request.carbohydrate())
+                .protein(request.protein())
+                .fat(request.fat())
+                .sodium(request.sodium())
+                .build();
+        Food food = Food.createWith(request.name(), weight, nutrient, memberId);
+
+        return foodRepository.save(food);
     }
 
     public PredictFoodSearchResponse foodSearch(final Long memberId, final String url) {

--- a/src/main/java/com/flab/eattofit/food/application/dto/FoodCreateRequest.java
+++ b/src/main/java/com/flab/eattofit/food/application/dto/FoodCreateRequest.java
@@ -35,6 +35,9 @@ public record FoodCreateRequest(
 
         @NotNull(message = "음식 나트륨이 있어야 합니다.")
         @DecimalMin(value = "0", message = "음식 나트륨은 0 이상이어야 합니다.")
-        BigDecimal sodium
+        BigDecimal sodium,
+
+        @NotEmpty(message = "음식 이미지 주소가 있어야 합니다.")
+        String url
 ) {
 }

--- a/src/main/java/com/flab/eattofit/food/application/dto/FoodCreateRequest.java
+++ b/src/main/java/com/flab/eattofit/food/application/dto/FoodCreateRequest.java
@@ -1,0 +1,40 @@
+package com.flab.eattofit.food.application.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record FoodCreateRequest(
+        @NotEmpty(message = "음식 이름이 있어야 합니다.")
+        String name,
+
+        @NotNull(message = "음식 사이즈가 있어야 합니다.")
+        @DecimalMin(value = "0", inclusive = false, message = "음식 사이즈는 0보다 커야 합니다.")
+        BigDecimal servingSize,
+
+        @NotEmpty(message = "음식 사이즈 단위가 있어야 합니다.")
+        String unit,
+
+        @NotNull(message = "음식 칼로리가 있어야 합니다.")
+        @DecimalMin(value = "0", message = "음식 칼로리는 0 이상이어야 합니다.")
+        BigDecimal kcal,
+
+        @NotNull(message = "음식 탄수화물이 있어야 합니다.")
+        @DecimalMin(value = "0", message = "음식 탄수화물은 0 이상이어야 합니다.")
+        BigDecimal carbohydrate,
+
+        @NotNull(message = "음식 단백질이 있어야 합니다.")
+        @DecimalMin(value = "0", message = "음식 단백질은 0 이상이어야 합니다.")
+        BigDecimal protein,
+
+        @NotNull(message = "음식 지방이 있어야 합니다.")
+        @DecimalMin(value = "0", message = "음식 지방은 0 이상이어야 합니다.")
+        BigDecimal fat,
+
+        @NotNull(message = "음식 나트륨이 있어야 합니다.")
+        @DecimalMin(value = "0", message = "음식 나트륨은 0 이상이어야 합니다.")
+        BigDecimal sodium
+) {
+}

--- a/src/main/java/com/flab/eattofit/food/domain/Food.java
+++ b/src/main/java/com/flab/eattofit/food/domain/Food.java
@@ -2,6 +2,7 @@ package com.flab.eattofit.food.domain;
 
 import com.flab.eattofit.food.domain.vo.FoodNutrient;
 import com.flab.eattofit.food.domain.vo.FoodWeight;
+import com.flab.eattofit.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Food {
+public class Food extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/flab/eattofit/food/domain/Food.java
+++ b/src/main/java/com/flab/eattofit/food/domain/Food.java
@@ -1,0 +1,51 @@
+package com.flab.eattofit.food.domain;
+
+import com.flab.eattofit.food.domain.vo.FoodNutrient;
+import com.flab.eattofit.food.domain.vo.FoodWeight;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Food {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Embedded
+    private FoodWeight weight;
+
+    @Embedded
+    private FoodNutrient nutrient;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    private Food(final String name, final FoodWeight weight, final FoodNutrient nutrient, final Long memberId) {
+        this.name = name;
+        this.weight = weight;
+        this.nutrient = nutrient;
+        this.memberId = memberId;
+    }
+
+    public static Food createWith(
+            final String name,
+            final FoodWeight weight,
+            final FoodNutrient nutrient,
+            final Long memberId
+    ) {
+        return new Food(name, weight, nutrient, memberId);
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/domain/Food.java
+++ b/src/main/java/com/flab/eattofit/food/domain/Food.java
@@ -12,9 +12,11 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
 @Entity
 public class Food extends BaseEntity {
 

--- a/src/main/java/com/flab/eattofit/food/domain/Food.java
+++ b/src/main/java/com/flab/eattofit/food/domain/Food.java
@@ -34,12 +34,16 @@ public class Food extends BaseEntity {
     private FoodNutrient nutrient;
 
     @Column(nullable = false)
+    private String url;
+
+    @Column(nullable = false)
     private Long memberId;
 
-    private Food(final String name, final FoodWeight weight, final FoodNutrient nutrient, final Long memberId) {
+    private Food(final String name, final FoodWeight weight, final FoodNutrient nutrient, final String url, final Long memberId) {
         this.name = name;
         this.weight = weight;
         this.nutrient = nutrient;
+        this.url = url;
         this.memberId = memberId;
     }
 
@@ -47,8 +51,9 @@ public class Food extends BaseEntity {
             final String name,
             final FoodWeight weight,
             final FoodNutrient nutrient,
+            final String url,
             final Long memberId
     ) {
-        return new Food(name, weight, nutrient, memberId);
+        return new Food(name, weight, nutrient, url, memberId);
     }
 }

--- a/src/main/java/com/flab/eattofit/food/domain/FoodRepository.java
+++ b/src/main/java/com/flab/eattofit/food/domain/FoodRepository.java
@@ -1,0 +1,6 @@
+package com.flab.eattofit.food.domain;
+
+public interface FoodRepository {
+
+    Food save(Food food);
+}

--- a/src/main/java/com/flab/eattofit/food/domain/vo/FoodNutrient.java
+++ b/src/main/java/com/flab/eattofit/food/domain/vo/FoodNutrient.java
@@ -1,0 +1,50 @@
+package com.flab.eattofit.food.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Embeddable
+public class FoodNutrient {
+
+    @Column(nullable = false)
+    private BigDecimal kcal;
+
+    @Column(nullable = false)
+    private BigDecimal carbohydrate;
+
+    @Column(nullable = false)
+    private BigDecimal protein;
+
+    @Column(nullable = false)
+    private BigDecimal fat;
+
+    @Column(nullable = false)
+    private BigDecimal sodium;
+
+    public static FoodNutrient createWith(
+            final BigDecimal kcal,
+            final BigDecimal carbohydrate,
+            final BigDecimal protein,
+            final BigDecimal fat,
+            final BigDecimal sodium
+    ) {
+        return FoodNutrient.builder()
+                .kcal(kcal)
+                .carbohydrate(carbohydrate)
+                .protein(protein)
+                .fat(fat)
+                .sodium(sodium)
+                .build();
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/domain/vo/FoodUnit.java
+++ b/src/main/java/com/flab/eattofit/food/domain/vo/FoodUnit.java
@@ -1,0 +1,29 @@
+package com.flab.eattofit.food.domain.vo;
+
+import com.flab.eattofit.food.exception.FoodUnitNotFoundException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum FoodUnit {
+    GRAM("g"),
+    KILOGRAM("kg");
+
+    private final String name;
+
+    FoodUnit(final String name) {
+        this.name = name;
+    }
+
+    public static FoodUnit findByName(final String name) {
+        return Arrays.stream(values())
+                .filter(unit -> unit.isSame(name))
+                .findAny()
+                .orElseThrow(FoodUnitNotFoundException::new);
+    }
+
+    private boolean isSame(final String name) {
+        return name.equals(this.name);
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/domain/vo/FoodWeight.java
+++ b/src/main/java/com/flab/eattofit/food/domain/vo/FoodWeight.java
@@ -1,0 +1,30 @@
+package com.flab.eattofit.food.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class FoodWeight {
+
+    @Column(nullable = false)
+    private BigDecimal servingSize;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    private FoodUnit unit;
+
+    public static FoodWeight createWith(final BigDecimal servingSize, final String unit) {
+        return new FoodWeight(servingSize, FoodUnit.findByName(unit));
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/exception/FoodUnitNotFoundException.java
+++ b/src/main/java/com/flab/eattofit/food/exception/FoodUnitNotFoundException.java
@@ -1,0 +1,11 @@
+package com.flab.eattofit.food.exception;
+
+import com.flab.eattofit.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class FoodUnitNotFoundException extends GlobalException  {
+
+    public FoodUnitNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "FOOD_UNIT_NOT_FOUND", "이용 가능한 음식 단위 타입이 아닙니다.");
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/infrastructure/FoodJpaRepository.java
+++ b/src/main/java/com/flab/eattofit/food/infrastructure/FoodJpaRepository.java
@@ -1,0 +1,9 @@
+package com.flab.eattofit.food.infrastructure;
+
+import com.flab.eattofit.food.domain.Food;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FoodJpaRepository extends JpaRepository<Food, Long> {
+
+    Food save(Food food);
+}

--- a/src/main/java/com/flab/eattofit/food/infrastructure/FoodRepositoryImpl.java
+++ b/src/main/java/com/flab/eattofit/food/infrastructure/FoodRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.flab.eattofit.food.infrastructure;
+
+import com.flab.eattofit.food.domain.Food;
+import com.flab.eattofit.food.domain.FoodRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class FoodRepositoryImpl implements FoodRepository {
+
+    private final FoodJpaRepository foodJpaRepository;
+
+    @Override
+    public Food save(final Food food) {
+        return foodJpaRepository.save(food);
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/ui/FoodController.java
+++ b/src/main/java/com/flab/eattofit/food/ui/FoodController.java
@@ -1,14 +1,22 @@
 package com.flab.eattofit.food.ui;
 
 import com.flab.eattofit.food.application.FoodService;
+import com.flab.eattofit.food.application.dto.FoodCreateRequest;
+import com.flab.eattofit.food.domain.Food;
 import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
+import com.flab.eattofit.food.ui.dto.FoodCreateResponse;
 import com.flab.eattofit.member.ui.auth.support.annotations.AuthMember;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/foods")
@@ -18,6 +26,16 @@ public class FoodController {
     private static final String IMAGE_URL = "image_url";
 
     private final FoodService foodService;
+
+    @PostMapping
+    public ResponseEntity<FoodCreateResponse> createFood(
+            @RequestBody @Valid final FoodCreateRequest request,
+            @AuthMember final Long memberId
+    ) {
+        Food food = foodService.createFood(request, memberId);
+        return ResponseEntity.created(URI.create("/foods/" + food.getId()))
+                .body(FoodCreateResponse.from(food));
+    }
 
     @GetMapping("/search")
     public ResponseEntity<PredictFoodSearchResponse> search(

--- a/src/main/java/com/flab/eattofit/food/ui/dto/FoodCreateResponse.java
+++ b/src/main/java/com/flab/eattofit/food/ui/dto/FoodCreateResponse.java
@@ -1,0 +1,40 @@
+package com.flab.eattofit.food.ui.dto;
+
+import com.flab.eattofit.food.domain.Food;
+import com.flab.eattofit.food.domain.vo.FoodNutrient;
+import com.flab.eattofit.food.domain.vo.FoodWeight;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record FoodCreateResponse(
+        String name,
+        BigDecimal servingSize,
+        String unit,
+        BigDecimal kcal,
+        BigDecimal carbohydrate,
+        BigDecimal protein,
+        BigDecimal fat,
+        BigDecimal sodium,
+        Long memberId,
+        LocalDateTime createdAt
+) {
+
+    public static FoodCreateResponse from(final Food food) {
+        FoodWeight weight = food.getWeight();
+        FoodNutrient nutrient = food.getNutrient();
+
+        return new FoodCreateResponse(
+                food.getName(),
+                weight.getServingSize(),
+                weight.getUnit().getName(),
+                nutrient.getKcal(),
+                nutrient.getCarbohydrate(),
+                nutrient.getProtein(),
+                nutrient.getFat(),
+                nutrient.getSodium(),
+                food.getMemberId(),
+                food.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/flab/eattofit/food/ui/dto/FoodCreateResponse.java
+++ b/src/main/java/com/flab/eattofit/food/ui/dto/FoodCreateResponse.java
@@ -16,6 +16,7 @@ public record FoodCreateResponse(
         BigDecimal protein,
         BigDecimal fat,
         BigDecimal sodium,
+        String url,
         Long memberId,
         LocalDateTime createdAt
 ) {
@@ -33,6 +34,7 @@ public record FoodCreateResponse(
                 nutrient.getProtein(),
                 nutrient.getFat(),
                 nutrient.getSodium(),
+                food.getUrl(),
                 food.getMemberId(),
                 food.getCreatedAt()
         );

--- a/src/main/java/com/flab/eattofit/global/domain/BaseEntity.java
+++ b/src/main/java/com/flab/eattofit/global/domain/BaseEntity.java
@@ -3,13 +3,19 @@ package com.flab.eattofit.global.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {

--- a/src/main/java/com/flab/eattofit/member/config/auth/MemberAuthConfig.java
+++ b/src/main/java/com/flab/eattofit/member/config/auth/MemberAuthConfig.java
@@ -41,7 +41,7 @@ public class MemberAuthConfig implements WebMvcConfigurer {
         return new PathMatcherInterceptor(memberLoginValidCheckerInterceptor)
                 .excludePathPatterns("/api/auth/login/**", POST)
                 .addPathPatterns("/api/storage/**", GET)
-                .addPathPatterns("/api/foods/**", GET)
+                .addPathPatterns("/api/foods/**", GET, POST)
                 .addPathPatterns("/api/members/**", GET, POST, PATCH, DELETE);
     }
 

--- a/src/main/resources/db/migration/V7__Add_Food.sql
+++ b/src/main/resources/db/migration/V7__Add_Food.sql
@@ -8,6 +8,7 @@ CREATE TABLE food(
     protein DECIMAL(5, 2) NOT NULL,
     fat DECIMAL(5, 2) NOT NULL,
     sodium DECIMAL(5, 2) NOT NULL,
+    url VARCHAR(255) NOT NULL,
     member_id BIGINT NOT NULL,
     PRIMARY KEY (id)
 );

--- a/src/main/resources/db/migration/V7__Add_Food.sql
+++ b/src/main/resources/db/migration/V7__Add_Food.sql
@@ -1,0 +1,13 @@
+CREATE TABLE food(
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    name CHAR(20) NOT NULL,
+    serving_size DECIMAL(5, 2) NOT NULL,
+    unit ENUM('GRAM', 'KILOGRAM') NOT NULL,
+    kcal DECIMAL(5, 2) NOT NULL,
+    carbohydrate DECIMAL(5, 2) NOT NULL,
+    protein DECIMAL(5, 2) NOT NULL,
+    fat DECIMAL(5, 2) NOT NULL,
+    sodium DECIMAL(5, 2) NOT NULL,
+    member_id BIGINT NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/test/java/com/flab/eattofit/food/application/FoodServiceTest.java
+++ b/src/test/java/com/flab/eattofit/food/application/FoodServiceTest.java
@@ -1,8 +1,10 @@
 package com.flab.eattofit.food.application;
 
+import com.flab.eattofit.food.domain.FoodRepository;
 import com.flab.eattofit.food.domain.FoodSearchManager;
 import com.flab.eattofit.food.exception.BadImageUrlException;
 import com.flab.eattofit.food.exception.FoodSearchJsonParseException;
+import com.flab.eattofit.food.infrastructure.FakeFoodRepository;
 import com.flab.eattofit.food.infrastructure.dto.FoodSearchResponse;
 import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,11 +31,14 @@ class FoodServiceTest {
     @Mock
     private FoodSearchManager foodSearchManager;
 
+    private FoodRepository foodRepository;
+
     private FoodService foodService;
 
     @BeforeEach
     void init() {
-        foodService = new FoodService(foodSearchManager);
+        foodRepository = new FakeFoodRepository();
+        foodService = new FoodService(foodRepository, foodSearchManager);
     }
 
     @Nested

--- a/src/test/java/com/flab/eattofit/food/application/FoodServiceTest.java
+++ b/src/test/java/com/flab/eattofit/food/application/FoodServiceTest.java
@@ -61,6 +61,7 @@ class FoodServiceTest {
             BigDecimal protein = BigDecimal.valueOf(25.0);
             BigDecimal fat = BigDecimal.valueOf(21.0);
             BigDecimal sodium = BigDecimal.valueOf(636.0);
+            String url = "burger.jpg";
 
             FoodCreateRequest request = new FoodCreateRequest(
                     name,
@@ -70,7 +71,8 @@ class FoodServiceTest {
                     carbohydrate,
                     protein,
                     fat,
-                    sodium
+                    sodium,
+                    url
             );
             Long memberId = 1L;
 
@@ -103,6 +105,7 @@ class FoodServiceTest {
             BigDecimal protein = BigDecimal.valueOf(25.0);
             BigDecimal fat = BigDecimal.valueOf(21.0);
             BigDecimal sodium = BigDecimal.valueOf(636.0);
+            String url = "burger.jpg";
 
             FoodCreateRequest request = new FoodCreateRequest(
                     name,
@@ -112,7 +115,8 @@ class FoodServiceTest {
                     carbohydrate,
                     protein,
                     fat,
-                    sodium
+                    sodium,
+                    url
             );
             Long memberId = 1L;
 

--- a/src/test/java/com/flab/eattofit/food/application/FoodServiceTest.java
+++ b/src/test/java/com/flab/eattofit/food/application/FoodServiceTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.math.BigDecimal;
+import static com.flab.eattofit.food.fixture.FoodCreateRequestFixture.음식_생성_요청_햄버거;
+import static com.flab.eattofit.food.fixture.FoodCreateRequestFixture.음식_생성_요청_햄버거_단위예외;
 import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_아님_빈_목록;
 import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_응답_비빔밥;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,27 +54,7 @@ class FoodServiceTest {
         @Test
         void 음식을_생성한다() {
             // given
-            String name = "햄버거";
-            BigDecimal servingSize = BigDecimal.valueOf(150.0);
-            String unit = "g";
-            BigDecimal kcal = BigDecimal.valueOf(430.0);
-            BigDecimal carbohydrate = BigDecimal.valueOf(36.0);
-            BigDecimal protein = BigDecimal.valueOf(25.0);
-            BigDecimal fat = BigDecimal.valueOf(21.0);
-            BigDecimal sodium = BigDecimal.valueOf(636.0);
-            String url = "burger.jpg";
-
-            FoodCreateRequest request = new FoodCreateRequest(
-                    name,
-                    servingSize,
-                    unit,
-                    kcal,
-                    carbohydrate,
-                    protein,
-                    fat,
-                    sodium,
-                    url
-            );
+            FoodCreateRequest request = 음식_생성_요청_햄버거();
             Long memberId = 1L;
 
             // when
@@ -83,41 +64,21 @@ class FoodServiceTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(food.getName()).isEqualTo(name);
-                softly.assertThat(weight.getServingSize()).isEqualTo(servingSize);
-                softly.assertThat(weight.getUnit().getName()).isEqualTo(unit);
-                softly.assertThat(nutrient.getKcal()).isEqualTo(kcal);
-                softly.assertThat(nutrient.getCarbohydrate()).isEqualTo(carbohydrate);
-                softly.assertThat(nutrient.getProtein()).isEqualTo(protein);
-                softly.assertThat(nutrient.getFat()).isEqualTo(fat);
-                softly.assertThat(nutrient.getSodium()).isEqualTo(sodium);
+                softly.assertThat(food.getName()).isEqualTo(request.name());
+                softly.assertThat(weight.getServingSize()).isEqualTo(request.servingSize());
+                softly.assertThat(weight.getUnit().getName()).isEqualTo(request.unit());
+                softly.assertThat(nutrient.getKcal()).isEqualTo(request.kcal());
+                softly.assertThat(nutrient.getCarbohydrate()).isEqualTo(request.carbohydrate());
+                softly.assertThat(nutrient.getProtein()).isEqualTo(request.protein());
+                softly.assertThat(nutrient.getFat()).isEqualTo(request.fat());
+                softly.assertThat(nutrient.getSodium()).isEqualTo(request.sodium());
             });
         }
 
         @Test
         void 잘못된_음식_무게_단위를_이용하면_예외가_발생한다() {
             // given
-            String name = "햄버거";
-            BigDecimal servingSize = BigDecimal.valueOf(150.0);
-            String unit = "abc";
-            BigDecimal kcal = BigDecimal.valueOf(430.0);
-            BigDecimal carbohydrate = BigDecimal.valueOf(36.0);
-            BigDecimal protein = BigDecimal.valueOf(25.0);
-            BigDecimal fat = BigDecimal.valueOf(21.0);
-            BigDecimal sodium = BigDecimal.valueOf(636.0);
-            String url = "burger.jpg";
-
-            FoodCreateRequest request = new FoodCreateRequest(
-                    name,
-                    servingSize,
-                    unit,
-                    kcal,
-                    carbohydrate,
-                    protein,
-                    fat,
-                    sodium,
-                    url
-            );
+            FoodCreateRequest request = 음식_생성_요청_햄버거_단위예외();
             Long memberId = 1L;
 
             // when & then

--- a/src/test/java/com/flab/eattofit/food/application/FoodServiceTest.java
+++ b/src/test/java/com/flab/eattofit/food/application/FoodServiceTest.java
@@ -1,9 +1,14 @@
 package com.flab.eattofit.food.application;
 
+import com.flab.eattofit.food.application.dto.FoodCreateRequest;
+import com.flab.eattofit.food.domain.Food;
 import com.flab.eattofit.food.domain.FoodRepository;
 import com.flab.eattofit.food.domain.FoodSearchManager;
+import com.flab.eattofit.food.domain.vo.FoodNutrient;
+import com.flab.eattofit.food.domain.vo.FoodWeight;
 import com.flab.eattofit.food.exception.BadImageUrlException;
 import com.flab.eattofit.food.exception.FoodSearchJsonParseException;
+import com.flab.eattofit.food.exception.FoodUnitNotFoundException;
 import com.flab.eattofit.food.infrastructure.FakeFoodRepository;
 import com.flab.eattofit.food.infrastructure.dto.FoodSearchResponse;
 import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
@@ -16,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
 import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_아님_빈_목록;
 import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_응답_비빔밥;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,6 +45,81 @@ class FoodServiceTest {
     void init() {
         foodRepository = new FakeFoodRepository();
         foodService = new FoodService(foodRepository, foodSearchManager);
+    }
+
+    @Nested
+    class 음식_생성 {
+
+        @Test
+        void 음식을_생성한다() {
+            // given
+            String name = "햄버거";
+            BigDecimal servingSize = BigDecimal.valueOf(150.0);
+            String unit = "g";
+            BigDecimal kcal = BigDecimal.valueOf(430.0);
+            BigDecimal carbohydrate = BigDecimal.valueOf(36.0);
+            BigDecimal protein = BigDecimal.valueOf(25.0);
+            BigDecimal fat = BigDecimal.valueOf(21.0);
+            BigDecimal sodium = BigDecimal.valueOf(636.0);
+
+            FoodCreateRequest request = new FoodCreateRequest(
+                    name,
+                    servingSize,
+                    unit,
+                    kcal,
+                    carbohydrate,
+                    protein,
+                    fat,
+                    sodium
+            );
+            Long memberId = 1L;
+
+            // when
+            Food food = foodService.createFood(request, memberId);
+            FoodWeight weight = food.getWeight();
+            FoodNutrient nutrient = food.getNutrient();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(food.getName()).isEqualTo(name);
+                softly.assertThat(weight.getServingSize()).isEqualTo(servingSize);
+                softly.assertThat(weight.getUnit().getName()).isEqualTo(unit);
+                softly.assertThat(nutrient.getKcal()).isEqualTo(kcal);
+                softly.assertThat(nutrient.getCarbohydrate()).isEqualTo(carbohydrate);
+                softly.assertThat(nutrient.getProtein()).isEqualTo(protein);
+                softly.assertThat(nutrient.getFat()).isEqualTo(fat);
+                softly.assertThat(nutrient.getSodium()).isEqualTo(sodium);
+            });
+        }
+
+        @Test
+        void 잘못된_음식_무게_단위를_이용하면_예외가_발생한다() {
+            // given
+            String name = "햄버거";
+            BigDecimal servingSize = BigDecimal.valueOf(150.0);
+            String unit = "abc";
+            BigDecimal kcal = BigDecimal.valueOf(430.0);
+            BigDecimal carbohydrate = BigDecimal.valueOf(36.0);
+            BigDecimal protein = BigDecimal.valueOf(25.0);
+            BigDecimal fat = BigDecimal.valueOf(21.0);
+            BigDecimal sodium = BigDecimal.valueOf(636.0);
+
+            FoodCreateRequest request = new FoodCreateRequest(
+                    name,
+                    servingSize,
+                    unit,
+                    kcal,
+                    carbohydrate,
+                    protein,
+                    fat,
+                    sodium
+            );
+            Long memberId = 1L;
+
+            // when & then
+            assertThatThrownBy(() -> foodService.createFood(request, memberId))
+                    .isInstanceOf(FoodUnitNotFoundException.class);
+        }
     }
 
     @Nested

--- a/src/test/java/com/flab/eattofit/food/domain/FoodTest.java
+++ b/src/test/java/com/flab/eattofit/food/domain/FoodTest.java
@@ -1,0 +1,50 @@
+package com.flab.eattofit.food.domain;
+
+import com.flab.eattofit.food.domain.vo.FoodNutrient;
+import com.flab.eattofit.food.domain.vo.FoodWeight;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class FoodTest {
+
+    @Nested
+    class 음식_생성 {
+
+        @Test
+        void 음식을_생성한다() {
+            // given
+            String name = "햄버거";
+            BigDecimal servingSize = BigDecimal.valueOf(123.45);
+            String unit = "g";
+            BigDecimal kcal = BigDecimal.valueOf(230.4);
+            BigDecimal carbohydrate = BigDecimal.valueOf(250);
+            BigDecimal protein = BigDecimal.valueOf(120);
+            BigDecimal fat = BigDecimal.valueOf(10);
+            BigDecimal sodium = BigDecimal.valueOf(20);
+            Long memberId = 1L;
+
+            FoodWeight weight = FoodWeight.createWith(servingSize, unit);
+            FoodNutrient nutrient = FoodNutrient.createWith(kcal, carbohydrate, protein, fat, sodium);
+
+            // when
+            Food food = Food.createWith(name, weight, nutrient, memberId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(food.getName()).isEqualTo(name);
+                softly.assertThat(food.getWeight()).usingRecursiveComparison()
+                                .isEqualTo(weight);
+                softly.assertThat(food.getNutrient()).usingRecursiveComparison()
+                                .isEqualTo(nutrient);
+                softly.assertThat(food.getMemberId()).isEqualTo(memberId);
+            });
+        }
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/domain/FoodTest.java
+++ b/src/test/java/com/flab/eattofit/food/domain/FoodTest.java
@@ -29,12 +29,13 @@ class FoodTest {
             BigDecimal fat = BigDecimal.valueOf(10);
             BigDecimal sodium = BigDecimal.valueOf(20);
             Long memberId = 1L;
+            String url = "burger.jpg";
 
             FoodWeight weight = FoodWeight.createWith(servingSize, unit);
             FoodNutrient nutrient = FoodNutrient.createWith(kcal, carbohydrate, protein, fat, sodium);
 
             // when
-            Food food = Food.createWith(name, weight, nutrient, memberId);
+            Food food = Food.createWith(name, weight, nutrient, url, memberId);
 
             // then
             assertSoftly(softly -> {

--- a/src/test/java/com/flab/eattofit/food/domain/vo/FoodNutrientTest.java
+++ b/src/test/java/com/flab/eattofit/food/domain/vo/FoodNutrientTest.java
@@ -1,0 +1,40 @@
+package com.flab.eattofit.food.domain.vo;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class FoodNutrientTest {
+
+    @Nested
+    class 음식_영양성분_생성 {
+
+        @Test
+        void 음식_영양성분을_생성한다() {
+            // given
+            BigDecimal kcal = BigDecimal.valueOf(635.31);
+            BigDecimal carbohydrate = BigDecimal.valueOf(97.13);
+            BigDecimal protein = BigDecimal.valueOf(24.21);
+            BigDecimal fat = BigDecimal.valueOf(16.23);
+            BigDecimal sodium = BigDecimal.valueOf(1248.24);
+
+            // when
+            FoodNutrient nutrient = FoodNutrient.createWith(kcal, carbohydrate, protein, fat, sodium);
+
+            // then
+            assertSoftly(softly -> {
+               softly.assertThat(nutrient.getKcal()).isEqualTo(kcal);
+               softly.assertThat(nutrient.getCarbohydrate()).isEqualTo(carbohydrate);
+               softly.assertThat(nutrient.getProtein()).isEqualTo(protein);
+               softly.assertThat(nutrient.getFat()).isEqualTo(fat);
+               softly.assertThat(nutrient.getSodium()).isEqualTo(sodium);
+            });
+        }
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/domain/vo/FoodUnitTest.java
+++ b/src/test/java/com/flab/eattofit/food/domain/vo/FoodUnitTest.java
@@ -1,0 +1,44 @@
+package com.flab.eattofit.food.domain.vo;
+
+import com.flab.eattofit.food.exception.FoodUnitNotFoundException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class FoodUnitTest {
+
+    @Nested
+    class 음식_무게_단위_조회 {
+
+        @Test
+        void 음식_무게_단위를_조회한다() {
+            // given
+            String value = "g";
+
+            // when
+            FoodUnit unit = FoodUnit.findByName(value);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(unit).isEqualTo(FoodUnit.GRAM);
+                softly.assertThat(unit.getName()).isEqualTo(value);
+            });
+        }
+
+        @Test
+        void 없는_음식_무게_단위를_조회면_예외가_발생한다() {
+            // given
+            String value = "abc";
+
+            // when & then
+            assertThatThrownBy(() -> FoodUnit.findByName(value))
+                    .isInstanceOf(FoodUnitNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/domain/vo/FoodWeightTest.java
+++ b/src/test/java/com/flab/eattofit/food/domain/vo/FoodWeightTest.java
@@ -1,0 +1,47 @@
+package com.flab.eattofit.food.domain.vo;
+
+import com.flab.eattofit.food.exception.FoodUnitNotFoundException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class FoodWeightTest {
+
+    @Nested
+    class 음식_무게_생성 {
+
+        @Test
+        void 음식_무게를_단위와_함께_생성한다() {
+            // given
+            BigDecimal servingSize = BigDecimal.valueOf(123.45);
+            String unit = "g";
+
+            // when
+            FoodWeight weight = FoodWeight.createWith(servingSize, unit);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(weight.getServingSize()).isEqualTo(servingSize);
+                softly.assertThat(weight.getUnit()).isEqualTo(FoodUnit.GRAM);
+            });
+        }
+
+        @Test
+        void 없는_무게_단위를_사용하면_예외가_발생한다() {
+            // given
+            BigDecimal servingSize = BigDecimal.valueOf(123.45);
+            String unit = "abc";
+
+            // when & then
+            assertThatThrownBy(() -> FoodWeight.createWith(servingSize, unit))
+                    .isInstanceOf(FoodUnitNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/fixture/FoodCreateRequestFixture.java
+++ b/src/test/java/com/flab/eattofit/food/fixture/FoodCreateRequestFixture.java
@@ -35,26 +35,17 @@ public class FoodCreateRequestFixture {
     }
 
     public static FoodCreateRequest 음식_생성_요청_햄버거_단위예외() {
-        String name = "햄버거";
-        BigDecimal servingSize = BigDecimal.valueOf(150.0);
-        String unit = "abc";
-        BigDecimal kcal = BigDecimal.valueOf(430.0);
-        BigDecimal carbohydrate = BigDecimal.valueOf(36.0);
-        BigDecimal protein = BigDecimal.valueOf(25.0);
-        BigDecimal fat = BigDecimal.valueOf(21.0);
-        BigDecimal sodium = BigDecimal.valueOf(636.0);
-        String url = "burger.jpg";
-
+        FoodCreateRequest request = 음식_생성_요청_햄버거();
         return new FoodCreateRequest(
-                name,
-                servingSize,
-                unit,
-                kcal,
-                carbohydrate,
-                protein,
-                fat,
-                sodium,
-                url
+                request.name(),
+                request.servingSize(),
+                "abc",
+                request.kcal(),
+                request.carbohydrate(),
+                request.protein(),
+                request.fat(),
+                request.sodium(),
+                request.url()
         );
     }
 }

--- a/src/test/java/com/flab/eattofit/food/fixture/FoodCreateRequestFixture.java
+++ b/src/test/java/com/flab/eattofit/food/fixture/FoodCreateRequestFixture.java
@@ -1,0 +1,60 @@
+package com.flab.eattofit.food.fixture;
+
+import com.flab.eattofit.food.application.dto.FoodCreateRequest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+import java.math.BigDecimal;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class FoodCreateRequestFixture {
+
+    public static FoodCreateRequest 음식_생성_요청_햄버거() {
+        String name = "햄버거";
+        BigDecimal servingSize = BigDecimal.valueOf(150.0);
+        String unit = "g";
+        BigDecimal kcal = BigDecimal.valueOf(430.0);
+        BigDecimal carbohydrate = BigDecimal.valueOf(36.0);
+        BigDecimal protein = BigDecimal.valueOf(25.0);
+        BigDecimal fat = BigDecimal.valueOf(21.0);
+        BigDecimal sodium = BigDecimal.valueOf(636.0);
+        String url = "burger.jpg";
+
+        return new FoodCreateRequest(
+                name,
+                servingSize,
+                unit,
+                kcal,
+                carbohydrate,
+                protein,
+                fat,
+                sodium,
+                url
+        );
+    }
+
+    public static FoodCreateRequest 음식_생성_요청_햄버거_단위예외() {
+        String name = "햄버거";
+        BigDecimal servingSize = BigDecimal.valueOf(150.0);
+        String unit = "abc";
+        BigDecimal kcal = BigDecimal.valueOf(430.0);
+        BigDecimal carbohydrate = BigDecimal.valueOf(36.0);
+        BigDecimal protein = BigDecimal.valueOf(25.0);
+        BigDecimal fat = BigDecimal.valueOf(21.0);
+        BigDecimal sodium = BigDecimal.valueOf(636.0);
+        String url = "burger.jpg";
+
+        return new FoodCreateRequest(
+                name,
+                servingSize,
+                unit,
+                kcal,
+                carbohydrate,
+                protein,
+                fat,
+                sodium,
+                url
+        );
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/fixture/FoodFixture.java
+++ b/src/test/java/com/flab/eattofit/food/fixture/FoodFixture.java
@@ -28,6 +28,7 @@ public class FoodFixture {
                 .name(request.name())
                 .weight(weight)
                 .nutrient(nutrient)
+                .url(request.url())
                 .memberId(memberId)
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/test/java/com/flab/eattofit/food/fixture/FoodFixture.java
+++ b/src/test/java/com/flab/eattofit/food/fixture/FoodFixture.java
@@ -1,0 +1,35 @@
+package com.flab.eattofit.food.fixture;
+
+import com.flab.eattofit.food.application.dto.FoodCreateRequest;
+import com.flab.eattofit.food.domain.Food;
+import com.flab.eattofit.food.domain.vo.FoodNutrient;
+import com.flab.eattofit.food.domain.vo.FoodWeight;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+import java.time.LocalDateTime;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class FoodFixture {
+
+    public static Food 음식_생성_응답_id있음(final FoodCreateRequest request, final Long memberId) {
+        FoodWeight weight = FoodWeight.createWith(request.servingSize(), request.unit());
+        FoodNutrient nutrient = FoodNutrient.createWith(
+                request.kcal(),
+                request.kcal(),
+                request.protein(),
+                request.fat(),
+                request.sodium()
+        );
+
+        return Food.builder()
+                .id(1L)
+                .name(request.name())
+                .weight(weight)
+                .nutrient(nutrient)
+                .memberId(memberId)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/infrastructure/FakeFoodRepository.java
+++ b/src/test/java/com/flab/eattofit/food/infrastructure/FakeFoodRepository.java
@@ -3,10 +3,26 @@ package com.flab.eattofit.food.infrastructure;
 import com.flab.eattofit.food.domain.Food;
 import com.flab.eattofit.food.domain.FoodRepository;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class FakeFoodRepository implements FoodRepository {
+
+    private final Map<Long, Food> map = new HashMap<>();
+    private Long id = 1L;
 
     @Override
     public Food save(final Food food) {
-        return null;
+        Food savedFood = Food.builder()
+                .id(id)
+                .name(food.getName())
+                .weight(food.getWeight())
+                .nutrient(food.getNutrient())
+                .memberId(food.getMemberId())
+                .createdAt(food.getCreatedAt())
+                .build();
+
+        map.put(id++, savedFood);
+        return savedFood;
     }
 }

--- a/src/test/java/com/flab/eattofit/food/infrastructure/FakeFoodRepository.java
+++ b/src/test/java/com/flab/eattofit/food/infrastructure/FakeFoodRepository.java
@@ -1,0 +1,12 @@
+package com.flab.eattofit.food.infrastructure;
+
+import com.flab.eattofit.food.domain.Food;
+import com.flab.eattofit.food.domain.FoodRepository;
+
+public class FakeFoodRepository implements FoodRepository {
+
+    @Override
+    public Food save(final Food food) {
+        return null;
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/infrastructure/FoodJpaRepositoryTest.java
+++ b/src/test/java/com/flab/eattofit/food/infrastructure/FoodJpaRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.flab.eattofit.food.infrastructure;
+
+import com.flab.eattofit.food.domain.Food;
+import com.flab.eattofit.food.domain.vo.FoodNutrient;
+import com.flab.eattofit.food.domain.vo.FoodWeight;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@DataJpaTest
+class FoodJpaRepositoryTest {
+
+    @Autowired
+    private FoodJpaRepository foodJpaRepository;
+
+    @Test
+    void 음식을_생성한다() {
+        // given
+        FoodWeight weight = FoodWeight.createWith(BigDecimal.valueOf(150.0), "g");
+        FoodNutrient nutrient = FoodNutrient.createWith(
+                BigDecimal.valueOf(430.0),
+                BigDecimal.valueOf(36.0),
+                BigDecimal.valueOf(25.0),
+                BigDecimal.valueOf(21.0),
+                BigDecimal.valueOf(636.0)
+        );
+        Long memberId = 1L;
+        Food food = Food.createWith("햄버거", weight, nutrient, memberId);
+
+        // when
+        Food savedFood = foodJpaRepository.save(food);
+
+        // then
+        assertThat(savedFood).usingRecursiveComparison()
+                .ignoringFields("id", "createdAt")
+                .isEqualTo(food);
+    }
+}

--- a/src/test/java/com/flab/eattofit/food/infrastructure/FoodJpaRepositoryTest.java
+++ b/src/test/java/com/flab/eattofit/food/infrastructure/FoodJpaRepositoryTest.java
@@ -32,7 +32,9 @@ class FoodJpaRepositoryTest {
                 BigDecimal.valueOf(636.0)
         );
         Long memberId = 1L;
-        Food food = Food.createWith("햄버거", weight, nutrient, memberId);
+        String url = "burger.jpg";
+
+        Food food = Food.createWith("햄버거", weight, nutrient, url, memberId);
 
         // when
         Food savedFood = foodJpaRepository.save(food);

--- a/src/test/java/com/flab/eattofit/food/ui/FoodControllerWebMvcTest.java
+++ b/src/test/java/com/flab/eattofit/food/ui/FoodControllerWebMvcTest.java
@@ -60,6 +60,7 @@ class FoodControllerWebMvcTest extends MockBeanInjection {
         BigDecimal protein = BigDecimal.valueOf(25.0);
         BigDecimal fat = BigDecimal.valueOf(21.0);
         BigDecimal sodium = BigDecimal.valueOf(636.0);
+        String url = "burger.jpg";
 
         FoodCreateRequest request = new FoodCreateRequest(
                 name,
@@ -69,7 +70,8 @@ class FoodControllerWebMvcTest extends MockBeanInjection {
                 carbohydrate,
                 protein,
                 fat,
-                sodium
+                sodium,
+                url
         );
         Long memberId = 1L;
         Food food = 음식_생성_응답_id있음(request, memberId);
@@ -95,7 +97,8 @@ class FoodControllerWebMvcTest extends MockBeanInjection {
                                 fieldWithPath("carbohydrate").description("음식 탄수화물"),
                                 fieldWithPath("protein").description("음식 단백질"),
                                 fieldWithPath("fat").description("음식 지방"),
-                                fieldWithPath("sodium").description("음식 나트륨")
+                                fieldWithPath("sodium").description("음식 나트륨"),
+                                fieldWithPath("url").description("음식 이미지 주소")
                         ),
                         responseHeaders(
                                 headerWithName("Location").description("등록된 음식 경로 (id 포함)")
@@ -110,6 +113,7 @@ class FoodControllerWebMvcTest extends MockBeanInjection {
                                 fieldWithPath("fat").description("음식 지방"),
                                 fieldWithPath("sodium").description("음식 나트륨"),
                                 fieldWithPath("memberId").description("생성한 회원 id"),
+                                fieldWithPath("url").description("음식 이미지 주소"),
                                 fieldWithPath("createdAt").description("음식 생성 시각")
                         )
                 ));

--- a/src/test/java/com/flab/eattofit/food/ui/FoodControllerWebMvcTest.java
+++ b/src/test/java/com/flab/eattofit/food/ui/FoodControllerWebMvcTest.java
@@ -1,5 +1,8 @@
 package com.flab.eattofit.food.ui;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.eattofit.food.application.dto.FoodCreateRequest;
+import com.flab.eattofit.food.domain.Food;
 import com.flab.eattofit.food.infrastructure.dto.PredictFoodSearchResponse;
 import com.flab.eattofit.helper.MockBeanInjection;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -10,19 +13,26 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.math.BigDecimal;
+import static com.flab.eattofit.food.fixture.FoodFixture.음식_생성_응답_id있음;
+import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_응답_비빔밥;
 import static com.flab.eattofit.helper.RestDocsHelper.customDocument;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_응답_비빔밥;
-import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -35,6 +45,75 @@ class FoodControllerWebMvcTest extends MockBeanInjection {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 음식을_생성한다() throws Exception {
+        // given
+        String name = "햄버거";
+        BigDecimal servingSize = BigDecimal.valueOf(150.0);
+        String unit = "g";
+        BigDecimal kcal = BigDecimal.valueOf(430.0);
+        BigDecimal carbohydrate = BigDecimal.valueOf(36.0);
+        BigDecimal protein = BigDecimal.valueOf(25.0);
+        BigDecimal fat = BigDecimal.valueOf(21.0);
+        BigDecimal sodium = BigDecimal.valueOf(636.0);
+
+        FoodCreateRequest request = new FoodCreateRequest(
+                name,
+                servingSize,
+                unit,
+                kcal,
+                carbohydrate,
+                protein,
+                fat,
+                sodium
+        );
+        Long memberId = 1L;
+        Food food = 음식_생성_응답_id있음(request, memberId);
+        when(foodService.createFood(any(), any())).thenReturn(food);
+
+        // when & then
+        mockMvc.perform(post("/api/foods")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header(AUTHORIZATION, BEARER_TOKEN))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/foods/" + food.getId()))
+                .andDo(print())
+                .andDo(customDocument("음식 생성",
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("유저 토큰 정보")
+                        ),
+                        requestFields(
+                                fieldWithPath("name").description("음식 이름"),
+                                fieldWithPath("servingSize").description("음식 사이즈"),
+                                fieldWithPath("unit").description("음식 사이즈 단위"),
+                                fieldWithPath("kcal").description("음식 칼로리"),
+                                fieldWithPath("carbohydrate").description("음식 탄수화물"),
+                                fieldWithPath("protein").description("음식 단백질"),
+                                fieldWithPath("fat").description("음식 지방"),
+                                fieldWithPath("sodium").description("음식 나트륨")
+                        ),
+                        responseHeaders(
+                                headerWithName("Location").description("등록된 음식 경로 (id 포함)")
+                        ),
+                        responseFields(
+                                fieldWithPath("name").description("음식 이름"),
+                                fieldWithPath("servingSize").description("음식 사이즈"),
+                                fieldWithPath("unit").description("음식 사이즈 단위"),
+                                fieldWithPath("kcal").description("음식 칼로리"),
+                                fieldWithPath("carbohydrate").description("음식 탄수화물"),
+                                fieldWithPath("protein").description("음식 단백질"),
+                                fieldWithPath("fat").description("음식 지방"),
+                                fieldWithPath("sodium").description("음식 나트륨"),
+                                fieldWithPath("memberId").description("생성한 회원 id"),
+                                fieldWithPath("createdAt").description("음식 생성 시각")
+                        )
+                ));
+    }
 
     @Test
     void 음식을_검색한다() throws Exception {

--- a/src/test/java/com/flab/eattofit/food/ui/FoodControllerWebMvcTest.java
+++ b/src/test/java/com/flab/eattofit/food/ui/FoodControllerWebMvcTest.java
@@ -13,7 +13,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.math.BigDecimal;
+import static com.flab.eattofit.food.fixture.FoodCreateRequestFixture.음식_생성_요청_햄버거;
 import static com.flab.eattofit.food.fixture.FoodFixture.음식_생성_응답_id있음;
 import static com.flab.eattofit.food.fixture.FoodSearchResponseFixture.음식_응답_비빔밥;
 import static com.flab.eattofit.helper.RestDocsHelper.customDocument;
@@ -52,27 +52,7 @@ class FoodControllerWebMvcTest extends MockBeanInjection {
     @Test
     void 음식을_생성한다() throws Exception {
         // given
-        String name = "햄버거";
-        BigDecimal servingSize = BigDecimal.valueOf(150.0);
-        String unit = "g";
-        BigDecimal kcal = BigDecimal.valueOf(430.0);
-        BigDecimal carbohydrate = BigDecimal.valueOf(36.0);
-        BigDecimal protein = BigDecimal.valueOf(25.0);
-        BigDecimal fat = BigDecimal.valueOf(21.0);
-        BigDecimal sodium = BigDecimal.valueOf(636.0);
-        String url = "burger.jpg";
-
-        FoodCreateRequest request = new FoodCreateRequest(
-                name,
-                servingSize,
-                unit,
-                kcal,
-                carbohydrate,
-                protein,
-                fat,
-                sodium,
-                url
-        );
+        FoodCreateRequest request = 음식_생성_요청_햄버거();
         Long memberId = 1L;
         Food food = 음식_생성_응답_id있음(request, memberId);
         when(foodService.createFood(any(), any())).thenReturn(food);


### PR DESCRIPTION
## 📢 Related Issue
<!-- 연결된 이슈를 등록해주세요. -->
* #20 
## 💁🏻 Summary
<!-- Pull Request의 전체적인 내용을 작성해주세요. -->
* 음식 등록 기능을 구현하였습니다. (음식 검색 후 클라이언트가 음식 정보를 등록하는 경우에 해당)
* 인수 테스트는 제외하였습니다. 보완 Pull Request는 별도로 올리겠습니다.
* 음식 사이즈, 음식 영양분에 대한 정보를 관리하는 VO (FoodWeight, FoodNutrient)를 두었습니다.
## 🧐 More
<!-- Pull Request와 관련된 고민, 리뷰어와 논의할 내용이 있다면 작성해주세요. -->
* SonaCloud에서 계속 중복 코드에 대한 경고를 내뱉고 있는데 이 부분을 논의하고 싶습니다. (FoodCreateRequestFixture)

close #20