### PR TITLE
[#22] 음식 플랜 생성 기능을 구현한다

### DIFF
--- a/src/docs/asciidoc/plan.adoc
+++ b/src/docs/asciidoc/plan.adoc
@@ -7,6 +7,18 @@
 
 == Plan
 
+=== 플랜 생성 (POST /api/plans)
+
+==== 요청
+include::{snippets}/plan-controller-web-mvc-test/플랜_생성/http-request.adoc[]
+include::{snippets}/plan-controller-web-mvc-test/플랜_생성/request-headers.adoc[]
+include::{snippets}/plan-controller-web-mvc-test/플랜_생성/request-fields.adoc[]
+
+==== 응답
+include::{snippets}/plan-controller-web-mvc-test/플랜_생성/http-response.adoc[]
+include::{snippets}/plan-controller-web-mvc-test/플랜_생성/response-headers.adoc[]
+include::{snippets}/plan-controller-web-mvc-test/플랜_생성/response-fields.adoc[]
+
 === 플랜 검색 (GET /api/plans/search)
 
 ==== 요청

--- a/src/main/java/com/flab/eattofit/plan/application/PlanService.java
+++ b/src/main/java/com/flab/eattofit/plan/application/PlanService.java
@@ -1,5 +1,8 @@
 package com.flab.eattofit.plan.application;
 
+import com.flab.eattofit.plan.application.dto.ExerciseCreateRequest;
+import com.flab.eattofit.plan.application.dto.PlanCreateRequest;
+import com.flab.eattofit.plan.domain.Plan;
 import com.flab.eattofit.plan.domain.PlanRepository;
 import com.flab.eattofit.plan.domain.PlanSearchManager;
 import com.flab.eattofit.plan.infrastructure.dto.PredictPlanSearchRequest;
@@ -10,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -19,6 +23,16 @@ public class PlanService {
 
     private final PlanRepository planRepository;
     private final PlanSearchManager planSearchManager;
+
+    public Plan createPlan(final PlanCreateRequest request, final Long memberId) {
+        Plan plan = Plan.createWith(request.type(), memberId);
+        List<ExerciseCreateRequest> exercises = request.exercises();
+        for (ExerciseCreateRequest exercise : exercises) {
+            plan.addExercise(exercise.name(), exercise.repeat(), exercise.expect(), exercise.size(), exercise.weight(), exercise.time());
+        }
+
+        return planRepository.save(plan);
+    }
 
     @Transactional(readOnly = true)
     public PredictPlanSearchResponse planSearch(final BigDecimal kcal, final Long memberId) {

--- a/src/main/java/com/flab/eattofit/plan/application/dto/ExerciseCreateRequest.java
+++ b/src/main/java/com/flab/eattofit/plan/application/dto/ExerciseCreateRequest.java
@@ -1,0 +1,25 @@
+package com.flab.eattofit.plan.application.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record ExerciseCreateRequest(
+        @NotEmpty(message = "등록할 운동 이름이 필요합니다.")
+        String name,
+
+        Integer repeat,
+
+        @NotNull(message = "등록할 운동의 예상 소모 칼로리가 필요합니다.")
+        @DecimalMin(value = "0", inclusive = false, message = "칼로리는 0보다 커야 합니다.")
+        BigDecimal expect,
+
+        Integer size,
+
+        BigDecimal weight,
+
+        Integer time
+) {
+}

--- a/src/main/java/com/flab/eattofit/plan/application/dto/PlanCreateRequest.java
+++ b/src/main/java/com/flab/eattofit/plan/application/dto/PlanCreateRequest.java
@@ -1,0 +1,17 @@
+package com.flab.eattofit.plan.application.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record PlanCreateRequest(
+        @NotEmpty(message = "플랜 타입이 필요합니다.")
+        String type,
+
+        @Valid
+        @NotNull(message = "플랜의 운동이 필요합니다.")
+        List<ExerciseCreateRequest> exercises
+) {
+}

--- a/src/main/java/com/flab/eattofit/plan/domain/Exercise.java
+++ b/src/main/java/com/flab/eattofit/plan/domain/Exercise.java
@@ -1,0 +1,75 @@
+package com.flab.eattofit.plan.domain;
+
+import com.flab.eattofit.global.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.math.BigDecimal;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Exercise extends BaseEntity {
+
+    private static final boolean EXERCISE_INITIAL_STATUS = false;
+    private static final boolean EXERCISE_DONE_STATUS = true;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private Integer repeat;
+
+    @Column(nullable = false)
+    private BigDecimal expect;
+
+    private Integer size;
+
+    private BigDecimal weight;
+
+    private Integer time;
+
+    @Column(nullable = false)
+    private Boolean isDone;
+
+    public static Exercise createFitness(
+            final String name,
+            final Integer repeat,
+            final BigDecimal expect,
+            final Integer size,
+            final BigDecimal weight
+    ) {
+        return Exercise.builder()
+                .name(name)
+                .repeat(repeat)
+                .expect(expect)
+                .size(size)
+                .weight(weight)
+                .time(null)
+                .isDone(EXERCISE_INITIAL_STATUS)
+                .build();
+    }
+
+    public static Exercise createSports(final String name, final BigDecimal expect, final Integer time) {
+        return Exercise.builder()
+                .name(name)
+                .repeat(null)
+                .expect(expect)
+                .size(null)
+                .weight(null)
+                .time(time)
+                .isDone(EXERCISE_INITIAL_STATUS)
+                .build();
+    }
+}

--- a/src/main/java/com/flab/eattofit/plan/domain/Exercise.java
+++ b/src/main/java/com/flab/eattofit/plan/domain/Exercise.java
@@ -29,6 +29,7 @@ public class Exercise extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column(name = "repeats")
     private Integer repeat;
 
     @Column(nullable = false)

--- a/src/main/java/com/flab/eattofit/plan/domain/Exercise.java
+++ b/src/main/java/com/flab/eattofit/plan/domain/Exercise.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -14,6 +15,7 @@ import lombok.experimental.SuperBuilder;
 import java.math.BigDecimal;
 
 @Getter
+@EqualsAndHashCode(exclude = {"id", "createdAt"})
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity

--- a/src/main/java/com/flab/eattofit/plan/domain/Plan.java
+++ b/src/main/java/com/flab/eattofit/plan/domain/Plan.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,7 +58,32 @@ public class Plan extends BaseEntity {
                 .build();
     }
 
-    public void addExercise(final Exercise exercise) {
-        this.exercises.add(exercise);
+    public void addExercise(
+            final String name,
+            final Integer repeat,
+            final BigDecimal expect,
+            final Integer size,
+            final BigDecimal weight,
+            final Integer time
+    ) {
+        if (this.type == PlanType.FITNESS) {
+            addFitness(name, repeat, expect, size, weight);
+            return;
+        }
+        addSports(name, expect, time);
+    }
+
+    private void addFitness(
+            final String name,
+            final Integer repeat,
+            final BigDecimal expect,
+            final Integer size,
+            final BigDecimal weight
+    ) {
+        this.exercises.add(Exercise.createFitness(name, repeat, expect, size, weight));
+    }
+
+    private void addSports(final String name, final BigDecimal expect, final Integer time) {
+        this.exercises.add(Exercise.createSports(name, expect, time));
     }
 }

--- a/src/main/java/com/flab/eattofit/plan/domain/Plan.java
+++ b/src/main/java/com/flab/eattofit/plan/domain/Plan.java
@@ -1,0 +1,63 @@
+package com.flab.eattofit.plan.domain;
+
+import com.flab.eattofit.global.domain.BaseEntity;
+import com.flab.eattofit.plan.domain.vo.PlanType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Plan extends BaseEntity {
+
+    private static final boolean PLAN_INITIAL_STATUS = false;
+    private static final boolean PLAN_DONE_STATUS = true;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PlanType type;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @JoinColumn(name = "plan_id")
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Exercise> exercises = new ArrayList<>();
+
+    @Column(nullable = false)
+    private Boolean isDone;
+
+    public static Plan createWith(final String type, final Long memberId) {
+        return Plan.builder()
+                .type(PlanType.findByName(type))
+                .memberId(memberId)
+                .exercises(new ArrayList<>())
+                .isDone(PLAN_INITIAL_STATUS)
+                .build();
+    }
+
+    public void addExercise(final Exercise exercise) {
+        this.exercises.add(exercise);
+    }
+}

--- a/src/main/java/com/flab/eattofit/plan/domain/PlanRepository.java
+++ b/src/main/java/com/flab/eattofit/plan/domain/PlanRepository.java
@@ -6,5 +6,6 @@ import java.math.BigDecimal;
 
 public interface PlanRepository {
 
+    Plan save(Plan plan);
     PredictPlanSearchRequest getPlanSearchRequest(BigDecimal kcal, Long memberId);
 }

--- a/src/main/java/com/flab/eattofit/plan/domain/vo/PlanType.java
+++ b/src/main/java/com/flab/eattofit/plan/domain/vo/PlanType.java
@@ -1,0 +1,30 @@
+package com.flab.eattofit.plan.domain.vo;
+
+import com.flab.eattofit.plan.exception.PlanTypeNotFoundException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum PlanType {
+
+    FITNESS("피트니스"),
+    SPORTS("스포츠");
+
+    private final String value;
+
+    PlanType(final String value) {
+        this.value = value;
+    }
+
+    public static PlanType findByName(final String name) {
+        return Arrays.stream(values())
+                .filter(type -> type.isSame(name))
+                .findAny()
+                .orElseThrow(PlanTypeNotFoundException::new);
+    }
+
+    private boolean isSame(final String name) {
+        return name.equals(this.value);
+    }
+}

--- a/src/main/java/com/flab/eattofit/plan/exception/PlanTypeNotFoundException.java
+++ b/src/main/java/com/flab/eattofit/plan/exception/PlanTypeNotFoundException.java
@@ -1,0 +1,11 @@
+package com.flab.eattofit.plan.exception;
+
+import com.flab.eattofit.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class PlanTypeNotFoundException extends GlobalException {
+
+    public PlanTypeNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "PLAN_TYPE_NOT_FOUND", "등록된 플랜 타입이 아닙니다.");
+    }
+}

--- a/src/main/java/com/flab/eattofit/plan/infrastructure/PlanJpaRepository.java
+++ b/src/main/java/com/flab/eattofit/plan/infrastructure/PlanJpaRepository.java
@@ -1,0 +1,9 @@
+package com.flab.eattofit.plan.infrastructure;
+
+import com.flab.eattofit.plan.domain.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanJpaRepository extends JpaRepository<Plan, Long> {
+
+    Plan save(Plan plan);
+}

--- a/src/main/java/com/flab/eattofit/plan/infrastructure/PlanRepositoryImpl.java
+++ b/src/main/java/com/flab/eattofit/plan/infrastructure/PlanRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.flab.eattofit.plan.infrastructure;
 
+import com.flab.eattofit.plan.domain.Plan;
 import com.flab.eattofit.plan.domain.PlanRepository;
 import com.flab.eattofit.plan.infrastructure.dto.PredictPlanSearchRequest;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,13 @@ import java.math.BigDecimal;
 @Component
 public class PlanRepositoryImpl implements PlanRepository {
 
+    private final PlanJpaRepository planJpaRepository;
     private final PlanQueryRepository planQueryRepository;
+
+    @Override
+    public Plan save(final Plan plan) {
+        return planJpaRepository.save(plan);
+    }
 
     @Override
     public PredictPlanSearchRequest getPlanSearchRequest(final BigDecimal kcal, final Long memberId) {

--- a/src/main/java/com/flab/eattofit/plan/ui/PlanController.java
+++ b/src/main/java/com/flab/eattofit/plan/ui/PlanController.java
@@ -2,15 +2,22 @@ package com.flab.eattofit.plan.ui;
 
 import com.flab.eattofit.member.ui.auth.support.annotations.AuthMember;
 import com.flab.eattofit.plan.application.PlanService;
+import com.flab.eattofit.plan.application.dto.PlanCreateRequest;
+import com.flab.eattofit.plan.domain.Plan;
 import com.flab.eattofit.plan.infrastructure.dto.PredictPlanSearchResponse;
+import com.flab.eattofit.plan.ui.dto.PlanCreateResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.math.BigDecimal;
+import java.net.URI;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/plans")
@@ -20,6 +27,16 @@ public class PlanController {
     private static final String KCAL = "kcal";
 
     private final PlanService planService;
+
+    @PostMapping
+    public ResponseEntity<PlanCreateResponse> createPlan(
+            @RequestBody @Valid final PlanCreateRequest request,
+            @AuthMember final Long memberId
+    ) {
+        Plan plan = planService.createPlan(request, memberId);
+        return ResponseEntity.created(URI.create("/plans/" + plan.getId()))
+                .body(PlanCreateResponse.from(plan));
+    }
 
     @GetMapping("/search")
     public ResponseEntity<PredictPlanSearchResponse> searchPredictPlans(

--- a/src/main/java/com/flab/eattofit/plan/ui/dto/PlanCreateResponse.java
+++ b/src/main/java/com/flab/eattofit/plan/ui/dto/PlanCreateResponse.java
@@ -1,0 +1,22 @@
+package com.flab.eattofit.plan.ui.dto;
+
+import com.flab.eattofit.plan.domain.Plan;
+
+import java.time.LocalDateTime;
+
+public record PlanCreateResponse(
+        Long id,
+        String type,
+        Boolean isDone,
+        LocalDateTime createdAt
+) {
+
+    public static PlanCreateResponse from(final Plan plan) {
+        return new PlanCreateResponse(
+                plan.getId(),
+                plan.getType().getValue(),
+                plan.getIsDone(),
+                plan.getCreatedAt()
+        );
+    }
+}

--- a/src/test/java/com/flab/eattofit/plan/application/PlanServiceTest.java
+++ b/src/test/java/com/flab/eattofit/plan/application/PlanServiceTest.java
@@ -1,8 +1,12 @@
 package com.flab.eattofit.plan.application;
 
 import com.flab.eattofit.global.exception.exceptions.AiResponseParseException;
+import com.flab.eattofit.plan.application.dto.PlanCreateRequest;
+import com.flab.eattofit.plan.domain.Plan;
 import com.flab.eattofit.plan.domain.PlanRepository;
 import com.flab.eattofit.plan.domain.PlanSearchManager;
+import com.flab.eattofit.plan.domain.vo.PlanType;
+import com.flab.eattofit.plan.exception.PlanTypeNotFoundException;
 import com.flab.eattofit.plan.infrastructure.PlanFakeRepository;
 import com.flab.eattofit.plan.infrastructure.dto.PlanSearchResponse;
 import com.flab.eattofit.plan.infrastructure.dto.PredictPlanSearchRequest;
@@ -17,6 +21,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import static com.flab.eattofit.plan.fixture.PlanCreateRequestFixture.플랜_생성_요청_없는_타입;
+import static com.flab.eattofit.plan.fixture.PlanCreateRequestFixture.플랜_생성_요청_피트니스_세개;
 import static com.flab.eattofit.plan.fixture.PlanSearchResponseFixture.플랜_응답_270;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -38,6 +44,39 @@ class PlanServiceTest {
     void init() {
         planRepository = new PlanFakeRepository();
         planService = new PlanService(planRepository, planSearchManager);
+    }
+
+    @Nested
+    class 플랜_생성 {
+
+        @Test
+        void 플랜을_생성한다() {
+            // given
+            PlanCreateRequest request = 플랜_생성_요청_피트니스_세개();
+            Long memberId = 1L;
+
+            // when
+            Plan plan = planService.createPlan(request, memberId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(plan.getType()).isEqualTo(PlanType.FITNESS);
+                softly.assertThat(plan.getMemberId()).isEqualTo(memberId);
+                softly.assertThat(plan.getExercises()).hasSize(3);
+                softly.assertThat(plan.getIsDone()).isFalse();
+            });
+        }
+
+        @Test
+        void 없는_타입으로_플랜을_생성하면_예외가_발생한다() {
+            // given
+            PlanCreateRequest request = 플랜_생성_요청_없는_타입();
+            Long memberId = 1L;
+
+            // when & then
+            assertThatThrownBy(() -> planService.createPlan(request, memberId))
+                    .isInstanceOf(PlanTypeNotFoundException.class);
+        }
     }
 
     @Nested

--- a/src/test/java/com/flab/eattofit/plan/domain/ExerciseTest.java
+++ b/src/test/java/com/flab/eattofit/plan/domain/ExerciseTest.java
@@ -1,0 +1,62 @@
+package com.flab.eattofit.plan.domain;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ExerciseTest {
+
+    @Nested
+    class 운동_생성 {
+
+        @Test
+        void 피트니스를_생성한다() {
+            // given
+            String name = "스쿼트";
+            int repeat = 10;
+            BigDecimal expect = BigDecimal.valueOf(100.5);
+            int size = 12;
+            BigDecimal weight = BigDecimal.valueOf(50);
+
+            // when
+            Exercise fitness = Exercise.createFitness(name, repeat, expect, size, weight);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(fitness.getName()).isEqualTo(name);
+                softly.assertThat(fitness.getRepeat()).isEqualTo(repeat);
+                softly.assertThat(fitness.getSize()).isEqualTo(size);
+                softly.assertThat(fitness.getWeight()).isEqualTo(weight);
+                softly.assertThat(fitness.getTime()).isNull();
+                softly.assertThat(fitness.getIsDone()).isFalse();
+            });
+        }
+
+        @Test
+        void 스포츠를_생성한다() {
+            // given
+            String name = "축구";
+            BigDecimal expect = BigDecimal.valueOf(100.5);
+            int time = 1800;
+
+            // when
+            Exercise sports = Exercise.createSports(name, expect, time);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(sports.getName()).isEqualTo(name);
+                softly.assertThat(sports.getRepeat()).isNull();
+                softly.assertThat(sports.getSize()).isNull();
+                softly.assertThat(sports.getWeight()).isNull();
+                softly.assertThat(sports.getTime()).isEqualTo(time);
+                softly.assertThat(sports.getIsDone()).isFalse();
+            });
+        }
+    }
+}

--- a/src/test/java/com/flab/eattofit/plan/domain/PlanTest.java
+++ b/src/test/java/com/flab/eattofit/plan/domain/PlanTest.java
@@ -1,0 +1,100 @@
+package com.flab.eattofit.plan.domain;
+
+import com.flab.eattofit.plan.domain.vo.PlanType;
+import com.flab.eattofit.plan.exception.PlanTypeNotFoundException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class PlanTest {
+
+    @Nested
+    class 플랜_생성 {
+
+        @Test
+        void 플랜을_생성한다() {
+            // given
+            String type = "피트니스";
+            Long memberId = 1L;
+
+            // when
+            Plan plan = Plan.createWith(type, memberId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(plan.getType()).isEqualTo(PlanType.FITNESS);
+                softly.assertThat(plan.getMemberId()).isEqualTo(memberId);
+                softly.assertThat(plan.getExercises()).isEmpty();
+                softly.assertThat(plan.getIsDone()).isFalse();
+            });
+        }
+
+        @Test
+        void 없는_타입으로_생성하면_예외가_발생한다() {
+            // given
+            String type = "abc";
+            Long memberId = 1L;
+
+            // when & then
+            assertThatThrownBy(() -> Plan.createWith(type, memberId))
+                    .isInstanceOf(PlanTypeNotFoundException.class);
+        }
+    }
+
+    @Nested
+    class 플랜_운동_추가 {
+
+        @Test
+        void 플랜에_피트니스를_추가한다() {
+            // given
+            String type = "피트니스";
+            Long memberId = 1L;
+            Plan plan = Plan.createWith(type, memberId);
+
+            String name = "스쿼트";
+            int repeat = 10;
+            BigDecimal expect = BigDecimal.valueOf(100.5);
+            int size = 12;
+            BigDecimal weight = BigDecimal.valueOf(50);
+            Exercise expectedExercise = Exercise.createFitness(name, repeat, expect, size, weight);
+
+            // when
+            plan.addExercise(name, repeat, expect, size, weight, null);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(plan.getExercises()).hasSize(1);
+                softly.assertThat(plan.getExercises()).contains(expectedExercise);
+            });
+        }
+
+        @Test
+        void 플랜에_스포츠를_추가한다() {
+            // given
+            String type = "스포츠";
+            Long memberId = 1L;
+            Plan plan = Plan.createWith(type, memberId);
+
+            String name = "축구";
+            BigDecimal expect = BigDecimal.valueOf(100.5);
+            int time = 1800;
+            Exercise expectedExercise = Exercise.createSports(name, expect, time);
+
+            // when
+            plan.addExercise(name, null, expect, null, null, time);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(plan.getExercises()).hasSize(1);
+                softly.assertThat(plan.getExercises()).contains(expectedExercise);
+            });
+        }
+    }
+}

--- a/src/test/java/com/flab/eattofit/plan/domain/vo/PlanTypeTest.java
+++ b/src/test/java/com/flab/eattofit/plan/domain/vo/PlanTypeTest.java
@@ -1,0 +1,44 @@
+package com.flab.eattofit.plan.domain.vo;
+
+import com.flab.eattofit.plan.exception.PlanTypeNotFoundException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class PlanTypeTest {
+
+    @Nested
+    class 플랜_타입_조회 {
+
+        @Test
+        void 플랜_타입을_조회한다() {
+            // given
+            String type = "피트니스";
+
+            // when
+            PlanType planType = PlanType.findByName(type);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(planType).isEqualTo(PlanType.FITNESS);
+                softly.assertThat(planType.getValue()).isEqualTo(type);
+            });
+        }
+
+        @Test
+        void 없는_플랜_타입을_조회하면_예외가_발생한다() {
+            // given
+            String type = "abc";
+
+            // when & then
+            assertThatThrownBy(() -> PlanType.findByName(type))
+                    .isInstanceOf(PlanTypeNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/flab/eattofit/plan/fixture/ExerciseCreateRequestFixture.java
+++ b/src/test/java/com/flab/eattofit/plan/fixture/ExerciseCreateRequestFixture.java
@@ -1,0 +1,42 @@
+package com.flab.eattofit.plan.fixture;
+
+import com.flab.eattofit.plan.application.dto.ExerciseCreateRequest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class ExerciseCreateRequestFixture {
+
+    public static List<ExerciseCreateRequest> 피트니스_생성_요청_세개() {
+        return List.of(
+                new ExerciseCreateRequest(
+                        "스쿼트",
+                        10,
+                        BigDecimal.valueOf(100.5),
+                        12,
+                        BigDecimal.valueOf(50),
+                        null
+                ),
+                new ExerciseCreateRequest(
+                        "레그 프레스",
+                        8,
+                        BigDecimal.valueOf(90.1),
+                        10,
+                        BigDecimal.valueOf(100),
+                        null
+                ),
+                new ExerciseCreateRequest(
+                        "랫 풀 다운",
+                        10,
+                        BigDecimal.valueOf(95.2),
+                        8,
+                        BigDecimal.valueOf(40),
+                        null
+                )
+        );
+    }
+}

--- a/src/test/java/com/flab/eattofit/plan/fixture/ExerciseFixture.java
+++ b/src/test/java/com/flab/eattofit/plan/fixture/ExerciseFixture.java
@@ -1,0 +1,61 @@
+package com.flab.eattofit.plan.fixture;
+
+import com.flab.eattofit.plan.domain.Exercise;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class ExerciseFixture {
+
+    public static List<Exercise> 피트니스_세개_id있음() {
+        return List.of(
+                스쿼트_id있음(),
+                레그프레스_id있음(),
+                랫풀다운_id있음()
+        );
+    }
+
+    private static Exercise 스쿼트_id있음() {
+        return Exercise.builder()
+                .id(1L)
+                .name("스쿼트")
+                .repeat(10)
+                .expect(BigDecimal.valueOf(100.5))
+                .size(12)
+                .weight(BigDecimal.valueOf(50))
+                .time(null)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private static Exercise 레그프레스_id있음() {
+        return Exercise.builder()
+                .id(2L)
+                .name("레그 프레스")
+                .repeat(8)
+                .expect(BigDecimal.valueOf(90.1))
+                .size(10)
+                .weight(BigDecimal.valueOf(100))
+                .time(null)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private static Exercise 랫풀다운_id있음() {
+        return Exercise.builder()
+                .id(3L)
+                .name("랫 풀 다운")
+                .repeat(10)
+                .expect(BigDecimal.valueOf(95.2))
+                .size(8)
+                .weight(BigDecimal.valueOf(40))
+                .time(null)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/com/flab/eattofit/plan/fixture/PlanCreateRequestFixture.java
+++ b/src/test/java/com/flab/eattofit/plan/fixture/PlanCreateRequestFixture.java
@@ -1,0 +1,20 @@
+package com.flab.eattofit.plan.fixture;
+
+import com.flab.eattofit.plan.application.dto.PlanCreateRequest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+import static com.flab.eattofit.plan.fixture.ExerciseCreateRequestFixture.피트니스_생성_요청_세개;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class PlanCreateRequestFixture {
+
+    public static PlanCreateRequest 플랜_생성_요청_피트니스_세개() {
+        return new PlanCreateRequest("피트니스", 피트니스_생성_요청_세개());
+    }
+
+    public static PlanCreateRequest 플랜_생성_요청_없는_타입() {
+        return new PlanCreateRequest("abc", 피트니스_생성_요청_세개());
+    }
+}

--- a/src/test/java/com/flab/eattofit/plan/fixture/PlanFixture.java
+++ b/src/test/java/com/flab/eattofit/plan/fixture/PlanFixture.java
@@ -1,0 +1,25 @@
+package com.flab.eattofit.plan.fixture;
+
+import com.flab.eattofit.plan.domain.Plan;
+import com.flab.eattofit.plan.domain.vo.PlanType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+import java.time.LocalDateTime;
+import static com.flab.eattofit.plan.fixture.ExerciseFixture.피트니스_세개_id있음;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class PlanFixture {
+
+    public static Plan 플랜_피트니스_세개(final Long memberId) {
+        return Plan.builder()
+                .id(1L)
+                .type(PlanType.FITNESS)
+                .memberId(memberId)
+                .exercises(피트니스_세개_id있음())
+                .isDone(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/com/flab/eattofit/plan/infrastructure/PlanFakeRepository.java
+++ b/src/test/java/com/flab/eattofit/plan/infrastructure/PlanFakeRepository.java
@@ -1,5 +1,6 @@
 package com.flab.eattofit.plan.infrastructure;
 
+import com.flab.eattofit.plan.domain.Plan;
 import com.flab.eattofit.plan.domain.PlanRepository;
 import com.flab.eattofit.plan.infrastructure.dto.MemberProfileResponse;
 import com.flab.eattofit.plan.infrastructure.dto.PredictPlanSearchRequest;
@@ -10,9 +11,28 @@ import com.flab.eattofit.profile.domain.exerciseprofile.vo.Level;
 import com.flab.eattofit.profile.domain.physicalprofile.vo.Gender;
 
 import java.math.BigDecimal;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class PlanFakeRepository implements PlanRepository {
+
+    private final Map<Long, Plan> map = new HashMap<>();
+    private Long id = 1L;
+
+    @Override
+    public Plan save(final Plan plan) {
+        Plan savedPlan = Plan.builder()
+                .id(id)
+                .type(plan.getType())
+                .memberId(plan.getMemberId())
+                .exercises(plan.getExercises())
+                .isDone(plan.getIsDone())
+                .build();
+
+        map.put(id++, savedPlan);
+        return savedPlan;
+    }
 
     @Override
     public PredictPlanSearchRequest getPlanSearchRequest(final BigDecimal kcal, final Long memberId) {

--- a/src/test/java/com/flab/eattofit/plan/infrastructure/PlanJpaRepositoryTest.java
+++ b/src/test/java/com/flab/eattofit/plan/infrastructure/PlanJpaRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.flab.eattofit.plan.infrastructure;
+
+import com.flab.eattofit.plan.domain.Plan;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@DataJpaTest
+class PlanJpaRepositoryTest {
+
+    @Autowired
+    private PlanJpaRepository planJpaRepository;
+
+    @Nested
+    class 플랜_생성 {
+
+        @Test
+        void 플랜을_생성한다() {
+            // given
+            String type = "피트니스";
+            Long memberId = 1L;
+            Plan plan = Plan.createWith(type, memberId);
+
+            // when
+            Plan savedPlan = planJpaRepository.save(plan);
+
+            // then
+            assertThat(savedPlan).usingRecursiveComparison()
+                    .ignoringFields("id", "createdAt")
+                    .isEqualTo(plan);
+        }
+
+        @Test
+        void 플랜을_운동과_함께_생성한다() {
+            // given
+            String type = "피트니스";
+            Long memberId = 1L;
+            Plan plan = Plan.createWith(type, memberId);
+            plan.addExercise("스쿼트", 10, BigDecimal.valueOf(100.5), 12, BigDecimal.valueOf(50), null);
+
+            // when
+            Plan savedPlan = planJpaRepository.save(plan);
+
+            // then
+            assertThat(savedPlan.getExercises()).hasSize(1);
+        }
+    }
+
+}

--- a/src/test/java/com/flab/eattofit/plan/ui/PlanControllerWebMvcTest.java
+++ b/src/test/java/com/flab/eattofit/plan/ui/PlanControllerWebMvcTest.java
@@ -1,6 +1,9 @@
 package com.flab.eattofit.plan.ui;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.eattofit.helper.MockBeanInjection;
+import com.flab.eattofit.plan.application.dto.PlanCreateRequest;
+import com.flab.eattofit.plan.domain.Plan;
 import com.flab.eattofit.plan.infrastructure.dto.PredictPlanSearchResponse;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -8,22 +11,29 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import static com.flab.eattofit.helper.RestDocsHelper.customDocument;
+import static com.flab.eattofit.plan.fixture.PlanCreateRequestFixture.플랜_생성_요청_피트니스_세개;
+import static com.flab.eattofit.plan.fixture.PlanFixture.플랜_피트니스_세개;
 import static com.flab.eattofit.plan.fixture.PlanSearchResponseFixture.플랜_응답_270;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -36,6 +46,51 @@ class PlanControllerWebMvcTest extends MockBeanInjection {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 플랜을_생성한다() throws Exception {
+        // given
+        PlanCreateRequest request = 플랜_생성_요청_피트니스_세개();
+        Long memberId = 1L;
+        Plan plan = 플랜_피트니스_세개(memberId);
+        when(planService.createPlan(any(), any())).thenReturn(plan);
+
+        // when & then
+        mockMvc.perform(post("/api/plans")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header(AUTHORIZATION, BEARER_TOKEN))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/plans/" + plan.getId()))
+                .andDo(print())
+                .andDo(customDocument("플랜_생성",
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("유저 토큰 정보")
+                        ),
+                        requestFields(
+                                fieldWithPath("type").description("플랜의 type"),
+                                fieldWithPath("exercises").description("플랜에 속한 하위 운동"),
+                                fieldWithPath("exercises[].name").description("하위 운동의 이름"),
+                                fieldWithPath("exercises[].repeat").description("피트니스의 전체 세트 횟수").optional(),
+                                fieldWithPath("exercises[].expect").description("각 운동의 예상 소모 칼로리"),
+                                fieldWithPath("exercises[].size").description("피트니스의 각 세트 안에서의 횟수").optional(),
+                                fieldWithPath("exercises[].weight").description("피트니스의 무게").optional(),
+                                fieldWithPath("exercises[].time").description("스포츠의 진행 시간 (초)").optional()
+                        ),
+                        responseHeaders(
+                                headerWithName("Location").description("등록된 플랜 경로 (id 포함)")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("플랜의 id"),
+                                fieldWithPath("type").description("플랜의 type"),
+                                fieldWithPath("isDone").description("플랜의 완료 여부"),
+                                fieldWithPath("createdAt").description("플랜의 생성 시각")
+                        ))
+                );
+    }
 
     @Test
     void 플랜을_검색한다() throws Exception {


### PR DESCRIPTION
## 📢 Related Issue
<!-- 연결된 이슈를 등록해주세요. -->
* #22 
## 💁🏻 Summary
<!-- Pull Request의 전체적인 내용을 작성해주세요. -->
* 플랜 생성에 대한 기능을 구현했습니다.

## 🧐 More
<!-- Pull Request와 관련된 고민, 리뷰어와 논의할 내용이 있다면 작성해주세요. -->
* 플랜을 생성할 때에는 하위 운동들을 가지고, 하위 운동들은 플랜이 생성될 때 생성되고 플랜이 제거될 때 함께 제거되므로 운동이 플랜의 생명 주기에 종속된다고 판단, 플랜을 애그리거트 루트로 취했습니다. (즉, 플랜 없이는 운동에 접근할 수 없습니다.)

close #22 